### PR TITLE
Fix name of qrels for TREC-Covid

### DIFF
--- a/pyterrier/datasets.py
+++ b/pyterrier/datasets.py
@@ -100,8 +100,8 @@ class RemoteDataset(Dataset):
 
 TREC_COVID_FILES = {
     "topics" : {
-        "round1" : ("topics-rnd1.xml", "https://ir.nist.gov/covidSubmit/data/topics-rnd3.xml", "trecxml"),
-        "round2" : ("topics-rnd2.xml", "https://ir.nist.gov/covidSubmit/data/topics-rnd3.xml", "trecxml"),
+        "round1" : ("topics-rnd1.xml", "https://ir.nist.gov/covidSubmit/data/topics-rnd1.xml", "trecxml"),
+        "round2" : ("topics-rnd2.xml", "https://ir.nist.gov/covidSubmit/data/topics-rnd2.xml", "trecxml"),
         "round3" : ("topics-rnd3.xml", "https://ir.nist.gov/covidSubmit/data/topics-rnd3.xml", "trecxml"),
     },
     "qrels" : {

--- a/pyterrier/datasets.py
+++ b/pyterrier/datasets.py
@@ -106,7 +106,7 @@ TREC_COVID_FILES = {
     },
     "qrels" : {
         "round1" : ("qrels-rnd1.txt", "https://ir.nist.gov/covidSubmit/data/qrels-rnd1.txt"),
-        "round2" : ("qrels-rnd1.txt", "https://ir.nist.gov/covidSubmit/data/qrels-rnd2.txt")
+        "round2" : ("qrels-rnd2.txt", "https://ir.nist.gov/covidSubmit/data/qrels-rnd2.txt")
     }
 }
 


### PR DESCRIPTION
It was not allowing get_residuals(qrels) to work properly for round2