### PR TITLE
IterDictIndexer

### DIFF
--- a/examples/notebooks/indexing.ipynb
+++ b/examples/notebooks/indexing.ipynb
@@ -580,6 +580,71 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "zjSUuBcou_L2",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Indexing a iterable, generator, etc.\n",
+        "\n",
+        "You may not want to load all documents into memory, particularly for large collections. Terrier can index iterable objects (e.g., generators) that yield `dict` objects.\n",
+        "\n",
+        "To do thise, we can use a `pt.IterDictIndexer()` object. By default, `text` will be indexed and `docno` will be stored in the meta index. These can be configured with the `fields` and `meta` parameters, respectively."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "CBYEKxK4u_uV",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "outputId": "f1880b9e-495e-44f2-a094-dbbf5ae7d1d9"
+      },
+      "source": [
+        "# As an example, we will stream the ANTIQUE collection.\n",
+        "# It is formatted as \"[docno] \\t [text] \\n\"\n",
+        "import urllib\n",
+        "import io\n",
+        "def antique_doc_iter():\n",
+        "    stream = urllib.request.urlopen('https://ciir.cs.umass.edu/downloads/Antique/antique-collection.txt')\n",
+        "    stream = io.TextIOWrapper(stream)\n",
+        "    for i, line in enumerate(stream):\n",
+        "        if i % 100000 == 0:\n",
+        "            print(f'processing document {i}')\n",
+        "        docno, text = line.rstrip().split('\\t')\n",
+        "        yield {'docno': docno, 'text': text}\n",
+        "\n",
+        "!rm -rf ./iter_index\n",
+        "iter_indexer = pt.IterDictIndexer(\"./iter_index\")\n",
+        "\n",
+        "doc_iter = antique_doc_iter()\n",
+        "indexref3 = iter_indexer.index(doc_iter)\n",
+        "\n",
+        "# Additional fields can be added in the dict. You can configure which fields are\n",
+        "# indexed and which are used as metadata with the fields and meta parameters.\n",
+        "# yield {'docno': docno, 'title': title, 'text': text, 'url': url}\n",
+        "# iter_indexer.index(doc_iter, fields=['text', 'title'], meta=['docno', 'url'])"
+      ],
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "processing document 0\n",
+            "processing document 100000\n",
+            "processing document 200000\n",
+            "processing document 300000\n",
+            "processing document 400000\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "IKrZNyaUXRMg",
         "colab_type": "text"
       },

--- a/pyterrier/__init__.py
+++ b/pyterrier/__init__.py
@@ -75,7 +75,7 @@ def init(version=None, mem=None, packages=[], jvm_opts=[], redirect_io=True, log
 
     from .batchretrieve import BatchRetrieve, FeaturesBatchRetrieve
     from .utils import Utils
-    from .index import Indexer, FilesIndexer, TRECCollectionIndexer, DFIndexer, DFIndexUtils, IndexingType
+    from .index import Indexer, FilesIndexer, TRECCollectionIndexer, DFIndexer, DFIndexUtils, IterDictIndexer, FlatJSONDocumentIterator, IndexingType
     from .pipelines import LTR_pipeline, XGBoostLTR_pipeline
 
     # Make imports global
@@ -119,6 +119,8 @@ def init(version=None, mem=None, packages=[], jvm_opts=[], redirect_io=True, log
     globals()["FilesIndexer"] = FilesIndexer
     globals()["DFIndexer"] = DFIndexer
     globals()["DFIndexUtils"] = DFIndexUtils
+    globals()["IterDictIndexer"] = IterDictIndexer
+    globals()["FlatJSONDocumentIterator"] = FlatJSONDocumentIterator
     globals()["Utils"] = Utils
     globals()["LTR_pipeline"] = LTR_pipeline
     globals()["XGBoostLTR_pipeline"] = XGBoostLTR_pipeline

--- a/pyterrier/__init__.py
+++ b/pyterrier/__init__.py
@@ -75,6 +75,7 @@ def init(version=None, mem=None, packages=[], jvm_opts=[], redirect_io=True, log
 
     from .batchretrieve import BatchRetrieve, FeaturesBatchRetrieve
     from .utils import Utils
+    from .datasets import get_dataset, list_datasets
     from .index import Indexer, FilesIndexer, TRECCollectionIndexer, DFIndexer, DFIndexUtils, IterDictIndexer, FlatJSONDocumentIterator, IndexingType
     from .pipelines import LTR_pipeline, XGBoostLTR_pipeline, Experiment
 

--- a/pyterrier/index.py
+++ b/pyterrier/index.py
@@ -442,7 +442,7 @@ class IterDictIndexer(Indexer):
             'indexer.meta.forward.keylens': ','.join(['512'] * len(meta))
         })
         # we need to prevent collectionIterator from being GCd
-        collectionIterator = FlatJSONDocumentIterator(it)
+        collectionIterator = FlatJSONDocumentIterator(iter(it)) # force it to be iter
         javaDocCollection = autoclass("org.terrier.python.CollectionFromDocumentIterator")(collectionIterator)
         index = self.createIndexer()
         index.index([javaDocCollection])

--- a/pyterrier/index.py
+++ b/pyterrier/index.py
@@ -9,10 +9,12 @@ import pandas as pd
 # import numpy as np
 import os
 import enum
+import json
 
 StringReader = None
 HashMap = None
 TaggedDocument = None
+FlatJSONDocument = None
 Tokeniser = None
 TRECCollection = None
 SimpleFileCollection = None
@@ -33,6 +35,7 @@ def run_autoclass():
     global StringReader
     global HashMap
     global TaggedDocument
+    global FlatJSONDocument
     global Tokeniser
     global TRECCollection
     global SimpleFileCollection
@@ -52,6 +55,7 @@ def run_autoclass():
     StringReader = autoclass("java.io.StringReader")
     HashMap = autoclass("java.util.HashMap")
     TaggedDocument = autoclass("org.terrier.indexing.TaggedDocument")
+    FlatJSONDocument = autoclass("org.terrier.indexing.FlatJSONDocument")
     Tokeniser = autoclass("org.terrier.indexing.tokenisation.Tokeniser")
     TRECCollection = autoclass("org.terrier.indexing.TRECCollection")
     SimpleFileCollection = autoclass("org.terrier.indexing.SimpleFileCollection")
@@ -333,6 +337,77 @@ class PythonListIterator(PythonJavaClass):
         if self.convertFn is not None:
             return self.convertFn(text, meta)
         return [text, meta]
+
+class FlatJSONDocumentIterator(PythonJavaClass):
+    __javainterfaces__ = ['java/util/Iterator']
+
+    def __init__(self, it):
+        super(FlatJSONDocumentIterator, self).__init__()
+        if FlatJSONDocument is None:
+            run_autoclass()
+        self._it = it
+        # easiest way to support hasNext is just to start consuming right away, I think
+        self._next = next(self._it, StopIteration)
+
+    @java_method('()V')
+    def remove():
+        # 1
+        pass
+
+    @java_method('(Ljava/util/function/Consumer;)V')
+    def forEachRemaining(action):
+        # 1
+        pass
+
+    @java_method('()Z')
+    def hasNext(self):
+        return self._next is not StopIteration
+
+    @java_method('()Ljava/lang/Object;')
+    def next(self):
+        result = self._next
+        self._next = next(self._it, StopIteration)
+        if result is not StopIteration:
+            return FlatJSONDocument(json.dumps(result))
+        return None
+
+class IterDictIndexer(Indexer):
+    """
+    Use this Indexer if you wish to index an iter of dicts (possibly with multiple fields)
+
+    Attributes:
+        default_properties(dict): Contains the default properties
+        path(str): The index directory + /data.properties
+        index_called(bool): True if index() method of child Indexer has been called, false otherwise
+        index_dir(str): The index directory
+        blocks(bool): If true the index has blocks enabled
+        properties: A Terrier Properties object, which is a hashtable with properties and their values
+        overwrite(bool): If True the index() method of child Indexer will overwrite any existing index
+    """
+    def index(self, it, fields=('text',), meta=('docno',)):
+        """
+        Index the specified iter of dicts with the (optional) specified fields
+
+        Args:
+            it(iter[dict]): an iter of document dict to be indexed
+            fields(list[str]): fieleds to be indexed (all will be considered metadata)
+        """
+        self.checkIndexExists()
+        self.setProperties(**{
+            'FieldTags.process': ','.join(fields),
+            'FieldTags.casesensitive': 'true',
+            'indexer.meta.forward.keys': ','.join(meta),
+            # What are the ramifications of setting all lengths to a large value like this? (storage cost?)
+            'indexer.meta.forward.keylens': ','.join(['512'] * len(meta))
+        })
+        # we need to prevent collectionIterator from being GCd
+        collectionIterator = FlatJSONDocumentIterator(it)
+        javaDocCollection = autoclass("org.terrier.python.CollectionFromDocumentIterator")(collectionIterator)
+        index = self.createIndexer()
+        index.index([javaDocCollection])
+        self.index_called = True
+        collectionIterator = None
+        return IndexRef.of(self.index_dir + "/data.properties")
 
 class TRECCollectionIndexer(Indexer):
     type_to_class = {

--- a/tests/test_iterdictindex.py
+++ b/tests/test_iterdictindex.py
@@ -1,0 +1,126 @@
+import pyterrier as pt
+
+import itertools
+import unittest
+import tempfile
+import shutil
+import os
+
+from .base import BaseTestCase
+
+class TestIterDictIndexer(BaseTestCase):
+
+    def setUp(self):
+        # Create a temporary directory
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        # Remove the directory after the test
+        shutil.rmtree(self.test_dir)
+
+    def _create_index(self, it, fields, meta, type):
+        pd_indexer = pt.IterDictIndexer(self.test_dir, type=type)
+        indexref = pd_indexer.index(it, fields, meta)
+        self.assertIsNotNone(indexref)
+        return indexref
+
+    def _make_check_index(self, n, single_pass, fields=('text',), meta=('docno', 'url', 'title')):
+        it = (
+            {'docno': '1', 'url': 'url1', 'text': 'He ran out of money, so he had to stop playing', 'title': 'Woes of playing poker'},
+            {'docno': '2', 'url': 'url2', 'text': 'The waves were crashing on the shore; it was a', 'title': 'Lovely sight'},
+            {'docno': '3', 'url': 'url3', 'text': 'The body may perhaps compensates for the loss', 'title': 'Best of Viktor Prowoll'},
+        )
+        it = itertools.islice(it, n)
+        if single_pass:
+            indexref = self._create_index(it, fields, meta, pt.IndexingType.SINGLEPASS)
+        else:
+            indexref = self._create_index(it, fields, meta, pt.IndexingType.CLASSIC)
+        index = pt.IndexFactory.of(indexref)
+        self.assertIsNotNone(index)
+        self.assertEqual(n, index.getCollectionStatistics().getNumberOfDocuments())
+        self.assertEqual(len(set(meta)), len(index.getMetaIndex().getKeys()))
+        for m in meta:
+            self.assertTrue(m in index.getMetaIndex().getKeys())
+        self.assertEqual(len(fields), index.getCollectionStatistics().numberOfFields)
+        for f in fields:
+            self.assertTrue(f in index.getCollectionStatistics().getFieldNames())
+        if single_pass:
+            self.assertFalse(os.path.isfile(self.test_dir + '/data.direct.bf'))
+        else:
+            self.assertTrue(os.path.isfile(self.test_dir + '/data.direct.bf'))
+        inv = index.getInvertedIndex()
+        lex = index.getLexicon()
+        post = inv.getPostings(lex.getLexiconEntry('plai'))
+        post.next()
+        from jnius import cast
+        post = cast("org.terrier.structures.postings.FieldPosting", post)
+        if 'title' in fields:
+            self.assertEqual(2, post.frequency)
+            self.assertEqual(1, post.fieldFrequencies[0])
+            self.assertEqual(1, post.fieldFrequencies[1])
+        else:
+            self.assertEqual(1, post.frequency)
+            self.assertEqual(1, post.fieldFrequencies[0])
+
+
+    def test_checkjavaDocIterator(self):
+        it = [
+            {'docno': '1', 'url': 'url1', 'text': 'He ran out of money, so he had to stop playing', 'title': 'Woes of playing poker'},
+            {'docno': '2', 'url': 'url2', 'text': 'The waves were crashing on the shore; it was a', 'title': 'Lovely sight'},
+            {'docno': '3', 'url': 'url3', 'text': 'The body may perhaps compensates for the loss', 'title': 'Best of Viktor Prowoll'},
+        ]
+
+        from pyterrier import FlatJSONDocumentIterator
+
+        it1 = itertools.islice(it, 1)
+        jIter1 = FlatJSONDocumentIterator(it1)
+        self.assertTrue(jIter1.hasNext())
+        self.assertIsNotNone(jIter1.next())
+        self.assertFalse(jIter1.hasNext())
+
+        it2 = itertools.islice(it, 2)
+        jIter1 = FlatJSONDocumentIterator(it2)
+        self.assertTrue(jIter1.hasNext())
+        self.assertIsNotNone(jIter1.next())
+        self.assertTrue(jIter1.hasNext())
+        self.assertIsNotNone(jIter1.next())
+        self.assertFalse(jIter1.hasNext())
+
+    def test_createindex1(self):
+        self._make_check_index(1, single_pass=False)
+
+    def test_createindex2(self):
+        self._make_check_index(2, single_pass=False)
+
+    def test_createindex3(self):
+        self._make_check_index(3, single_pass=False)
+
+    def test_createindex1_single_pass(self):
+        self._make_check_index(1, single_pass=True)
+
+    def test_createindex2_single_pass(self):
+        self._make_check_index(2, single_pass=True)
+
+    def test_createindex3_single_pass(self):
+        self._make_check_index(3, single_pass=True)
+
+    def test_createindex1_2fields(self):
+        self._make_check_index(1, single_pass=False, fields=['text', 'title'])
+
+    def test_createindex2_2fields(self):
+        self._make_check_index(2, single_pass=False, fields=['text', 'title'])
+
+    def test_createindex3_2fields(self):
+        self._make_check_index(3, single_pass=False, fields=['text', 'title'])
+
+    def test_createindex1_single_pass_2fields(self):
+        self._make_check_index(1, single_pass=True, fields=['text', 'title'])
+
+    def test_createindex2_single_pass_2fields(self):
+        self._make_check_index(2, single_pass=True, fields=['text', 'title'])
+
+    def test_createindex3_single_pass_2fields(self):
+        self._make_check_index(3, single_pass=True, fields=['text', 'title'])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Motivation: The existing `DFIndexer` requires entire collection to be loaded into memory, which could be a problem for large collections. It also doesn't currently support indexing multiple fields or customizing which fields are stored in the meta index [1]. This PR addresses both issues by allowing the user to send an iter of dict objects, where each key in the dict corresponds to a field to be indexed or a meta field (controlled by `field` and `meta` parameters). I simply use the `org.terrier.indexing.FlatJSONDocument` to handle all the field stuff, rather than rolling my own implementation because it seems to handle the cases I foresee. Tests included.

[1] Aside: Is meta index field functionality broken for `DFIndexer`? The code seems like it was [meant to support this](https://github.com/terrier-org/pyterrier/blob/master/pyterrier/index.py#L227), but the tests [show that it doesn't work](https://github.com/terrier-org/pyterrier/blob/master/tests/test_dfindex.py#L46).