### PR TITLE
speeding up convert_qrels_to_dict

### DIFF
--- a/pyterrier/utils.py
+++ b/pyterrier/utils.py
@@ -213,9 +213,9 @@ class Utils:
         Returns:
             dict: {qid:{docno:label,},}
         """
-        run_dict_pytrec_eval = defaultdict(dict)     
-        for index, row in df.iterrows():
-            run_dict_pytrec_eval[row['qid']][row['docno']] = int(row['label'])
+        run_dict_pytrec_eval = defaultdict(dict)
+        for row in df.itertuples():
+            run_dict_pytrec_eval[row.qid][row.docno] = int(row.label)
         return(run_dict_pytrec_eval)
 
     @staticmethod

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import pandas as pd
-
 import pyterrier as pt
 import unittest
 import os
@@ -65,6 +64,13 @@ class TestUtils(BaseTestCase):
         #print(exp_result)
         #print(result)
         pd.testing.assert_frame_equal(exp_result, result)
+
+    def test_convert_qrels_to_dict(self):
+        input = os.path.dirname(os.path.realpath(__file__)) + "/fixtures/qrels"
+        exp_result = {"1": {"13": 1, "15": 1}, "2": {"17": 1, "8": 1, "4": 1}, "3": {"2": 1}}
+        df = pt.Utils.parse_qrels(input)
+        result = dict(pt.Utils.convert_qrels_to_dict(df))
+        self.assertEqual(exp_result, result)
 
     def test_evaluate(self):
         input_qrels = pd.DataFrame([["1", "12", 1], ["1", "26", 1], ["1", "5", 1], ["1", "6", 1], ["2", "12", 1], ["2", "13", 1], ["2", "7", 1], ["2", "17", 1]], columns=["qid", "docno", "label"])


### PR DESCRIPTION
Related to #37. Speeding up convert_qrels_to_dict 100x using itertuples instead of iterrows. itertuples is faster because it avoids boxing the rows in pd.Series. I'm surprised it made so much of a difference here. Maybe due to the large number of rows in my test file (311,410).

My timing code:

```
import pyterrier; pyterrier.init()
df = pyterrier.Utils.parse_qrels('robust04.qrels')

import timeit
result = timeit.timeit(lambda: pyterrier.Utils.convert_qrels_to_dict(df), number=5)
print(result) # total time for 5 executions in seconds
```

Before (with iterrows)
```
142.19985203596298
```

After (with itertuples)
```
1.3646108560496941
```