### PR TITLE
addresses move methods in Utils into better name #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ See examples in the [indexing notebook](examples/notebooks/indexing.ipynb) [![Op
 # Retrieval and Evaluation
 
 ```python
-topics = pt.Utils.parse_trec_topics_file(topicsFile)
-qrels = pt.Utils.parse_qrels(qrelsFile)
+topics = pt.io.read_topics(topicsFile)
+qrels = pt.io.read_qrels(qrelsFile)
 BM25_br = pt.BatchRetrieve(index, controls={"wmodel": "BM25"})
 res = BM25_br.transform(topics)
 pt.Utils.evaluate(res, qrels, metrics = ['map'])

--- a/examples/notebooks/retrieval_and_evaluation.ipynb
+++ b/examples/notebooks/retrieval_and_evaluation.ipynb
@@ -1,18 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "Retrieval and Evaluation.ipynb",
-      "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -226,10 +212,10 @@
         "colab_type": "text"
       },
       "source": [
-        "Normally, we would use pt.Utils.parse_trec_topics_file(topics_path) to parse a topics file. \n",
+        "Normally, we would use pt.io.read_topics(topics_path) to parse a topics file. \n",
         "``` python\n",
         "topics_path = \"./query-text.trec\"\n",
-        "topics = pt.Utils.parse_trec_topics_file(topics_path)\n",
+        "topics = pt.io.read_topics(topics_path)\n",
         "```\n",
         "\n",
         "However, the pt.dataset gives the topics and qrels readily-parsed:\n",
@@ -646,7 +632,7 @@
         "Similarly, if working with a local test collection, we can use pt.Utils.parse_qrels(qrels_path) to parse a qrels file:\n",
         "```python\n",
         "qrels_path=(\"./qrels\")\n",
-        "qrels = pt.Utils.parse_qrels(qrels_path)\n",
+        "qrels = pt.io.read_qrels(qrels_path)\n",
         "```\n",
         "\n",
         "However, for the Vaswani dataset, the qrels are provided ready-to-do:\n"
@@ -867,5 +853,19 @@
       "execution_count": 0,
       "outputs": []
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "name": "Retrieval and Evaluation.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/pyterrier/__init__.py
+++ b/pyterrier/__init__.py
@@ -13,6 +13,7 @@ pipelines = None
 anserini = None
 transformer = None
 cache = None
+io = None
 file_path = os.path.dirname(os.path.abspath(__file__))
 firstInit = False
 ApplicationSetup = None
@@ -97,13 +98,14 @@ def init(version=None, mem=None, packages=[], jvm_opts=[], redirect_io=True, log
     global index
     global transformer
     global cache
+    global io
     rewrite = importlib.import_module('.rewrite', package='pyterrier') 
     anserini = importlib.import_module('.anserini', package='pyterrier') 
     pipelines = importlib.import_module('.pipelines', package='pyterrier') 
     index = importlib.import_module('.index', package='pyterrier') 
     transformer = importlib.import_module('.transformer', package='pyterrier') 
     cache = importlib.import_module('.cache', package='pyterrier') 
-
+    io = importlib.import_module('.io', package='pyterrier') 
 
     # append the python helpers
     if packages is None:

--- a/pyterrier/batchretrieve.py
+++ b/pyterrier/batchretrieve.py
@@ -230,7 +230,7 @@ class BatchRetrieve(BatchRetrieveBase):
         return "BR(" + self.controls["wmodel"] + ")"
 
     @deprecation.deprecated(deprecated_in="0.3.0",
-                        details="Please use pt.Utils.write_results_trec()")
+                        details="Please use pt.io.write_results(res, path, format='trec')")
     def saveResult(self, result, path, run_name=None):
         if run_name is None:
             run_name = self.controls["wmodel"]

--- a/pyterrier/datasets.py
+++ b/pyterrier/datasets.py
@@ -159,7 +159,7 @@ class RemoteDataset(Dataset):
     def get_topics(self, variant=None, **kwargs):
         import pyterrier as pt
         file, filetype = self._get_one_file("topics", variant)
-        if filetype is None or filetype in pt.io.SUPPORTED_TOPIC_FORMATS:
+        if filetype is None or filetype in pt.io.SUPPORTED_TOPICS_FORMATS:
             return pt.io.read_topics(file, format=filetype, **kwargs)
         elif filetype == "direct":
             return file
@@ -206,7 +206,7 @@ TREC_DEEPLEARNING_MSMARCO_FILES = {
 def remove_prefix(self, component, variant):
     import pyterrier as pt
     topics_file, type = self._get_one_file("topics_prefixed", variant)
-    if type in pt.io.SUPPORTED_TOPIC_FORMATS:
+    if type in pt.io.SUPPORTED_TOPICS_FORMATS:
         topics = pt.io.read_topics(topics_file, type)
     else:
         raise ValueError("Unknown topic type %s" % type)

--- a/pyterrier/datasets.py
+++ b/pyterrier/datasets.py
@@ -154,17 +154,13 @@ class RemoteDataset(Dataset):
         filename, type = self._get_one_file("qrels", variant)
         if type == "direct":
             return filename 
-        return pt.Utils.parse_qrels(filename)
+        return pt.io.read_qrels(filename)
 
     def get_topics(self, variant=None, **kwargs):
         import pyterrier as pt
         file, filetype = self._get_one_file("topics", variant)
-        if filetype is None or filetype == "trec":
-            return pt.Utils.parse_trec_topics_file(file, **kwargs)
-        elif filetype == "singleline":
-            return pt.Utils.parse_singleline_topics_file(file, **kwargs)
-        elif filetype == "trecxml":
-            return pt.Utils.parse_trecxml_topics_file(file, **kwargs)
+        if filetype is None or filetype in pt.io.SUPPORTED_TOPIC_FORMATS:
+            return pt.io.read_topics(file, format=filetype, **kwargs)
         elif filetype == "direct":
             return file
         raise ValueError("Unknown filetype %s for %s topics %s"  % (filetype, self.name, variant))
@@ -210,10 +206,8 @@ TREC_DEEPLEARNING_MSMARCO_FILES = {
 def remove_prefix(self, component, variant):
     import pyterrier as pt
     topics_file, type = self._get_one_file("topics_prefixed", variant)
-    if type == "trec":
-        topics = pt.Utils.parse_trec_topics_file(topics_file)
-    elif type == "singleline":
-        topics = pt.Utils.parse_singleline_topics_file(topics_file)
+    if type in pt.io.SUPPORTED_TOPIC_FORMATS:
+        topics = pt.io.read_topics(topics_file, type)
     else:
         raise ValueError("Unknown topic type %s" % type)
     topics["qid"] = topics.apply(lambda row: row["qid"].split("-")[1], axis=1)
@@ -224,7 +218,7 @@ def remove_prefix(self, component, variant):
 def parse_desc_only(self, component, variant):
     import pyterrier as pt
     file, type = self._get_one_file("topics_special_np")
-    topics = pt.Utils.parse_trec_topics_file(file, whitelist=["DESC"], blacklist=None)
+    topics = pt.io.read_topics(file, format="trec", whitelist=["DESC"], blacklist=None)
     topics["qid"] = topics.apply(lambda row: row["qid"].replace("NP", ""), axis=1)
     return (topics, "direct")
 

--- a/pyterrier/io.py
+++ b/pyterrier/io.py
@@ -1,0 +1,200 @@
+import pandas as pd
+
+
+SUPPORTED_TOPIC_FORMATS = ["trec", "trecxml", "singleline"]
+
+def autoopen(filename, mode='rb'):
+    if filename.endswith(".gz"):
+        import gzip
+        return gzip.open(filename, mode)
+    elif filename.endswith(".bz2"):
+        import bz2
+        return bz2.open(filename, mode)
+    return open(filename, mode)
+
+def read_results(filename, format="trec", **kwargs):
+    if format == "trec" or format is None:
+        return _read_results_trec(filename)
+    elif format == "letor":
+        return _read_results_letor(filename, **kwargs)
+    else:
+        raise ValueError("Format %s not known, possible values are trec or letor" % format)
+
+def _read_results_letor(filename, labels=False):
+
+    def _parse_line(l):
+            # $line =~ s/(#.*)$//;
+            # my $comment = $1;
+            # my @parts = split /\s+/, $line;
+            # my $label = shift @parts;
+            # my %hash = map {split /:/, $_} @parts;
+            # return ($label, $comment, %hash);
+        import re
+        import numpy as np
+        line, comment = l.split("#")
+        line = line.strip()
+        parts = re.split(r'\s+|:', line)
+        label = parts.pop(0)
+        m = re.search(r'docno\s?=\s?(\S+)', comment)
+        docno = m.group(1)
+        kv = {}
+        qid = None
+        for i, k in enumerate(parts):
+            if i % 2 == 0:
+                if k == "qid":
+                    qid = parts[i+1]
+                else:
+                    kv[int(k)] = float(parts[i+1])
+        features = np.array([kv[i] for i in sorted(kv.keys())])
+        return (label, qid, docno, features)       
+
+    with autoopen(filename, 'rt') as f:
+        rows = []
+        for line in f:
+            if line.startswith("#"):
+                continue
+            (label, qid, docno, features) = _parse_line(line)
+            if labels:
+                rows.append([qid, docno, features, label])
+            else:
+                rows.append([qid, docno, features])
+        return pd.DataFrame(rows, columns=["qid", "docno", "features", "label"] if labels else ["qid", "docno", "features"])
+
+def _read_results_trec(filename):
+    results = []
+    df = pd.read_csv(filename, sep=r'\s+', names=["qid", "iter", "docno", "rank", "score", "name"])
+    df = df.drop(columns="iter")
+    df["qid"] = df["qid"].astype(str)
+    df["docno"] = df["docno"].astype(str)
+    df["rank"] = df["rank"].astype(int)
+    df["score"] = df["score"].astype(float)
+    return df
+
+def write_results(res, filename, format="trec", **kwargs):
+    if format == "trec" or format is None:
+        _write_results_trec(res, filename, **kwargs)
+    elif format == "letor":
+        _write_results_letor(res, filename, **kwargs)
+    else:
+        raise ValueError("Format %s not known, possible values are trec or letor")
+
+def _write_results_trec(res, filename, run_name="pyterrier"):
+        res_copy = res.copy()[["qid", "docno", "rank", "score"]]
+        res_copy.insert(1, "Q0", "Q0")
+        res_copy.insert(5, "run_name", run_name)
+        res_copy.to_csv(filename, sep=" ", header=False, index=False)
+
+def _write_results_letor(res, filename, qrels=None, default_label=0):
+    if qrels is not None:
+        res = res.merge(qrels, on=['qid', 'docno'], how='left').fillna(default_label)
+    with autoopen(filename, "wt") as f:
+        for row in res.itertuples():
+            values = row.features
+            label = row.label if qrels is not None else default_label
+            feat_str = ' '.join( [ '%i:%f' % (i+1,values[i]) for i in range(len(values)) ] )
+            f.write("%d qid:%s %s # docno=%s\n" % (label, row.qid, feat_str, row.docno))
+
+def read_topics(filename, format="trec", **kwargs):
+    if format == "trec" or format is None:
+        return _read_topics_trec(filename, **kwargs)
+    elif format == "trec":
+        return _read_topics_trecxml(filename, **kwargs)    
+    elif format == "singleline":
+        return _read_topics_singleline(filename, **kwargs)
+    else:
+        raise ValueError("Format %s not known, possible values are trec, trecxml or singleline")
+
+def _read_topics_trec(file_path, doc_tag="TOP", id_tag="NUM", whitelist=["TITLE"], blacklist=["DESC","NARR"]):
+    """
+    Parse a file containing topics in standard TREC format
+
+    Args:
+        file_path(str): The path to the topics file
+
+    Returns:
+        pandas.Dataframe with columns=['qid','query']
+        both columns have type string
+    """
+    from jnius import autoclass
+    from . import check_version
+    assert check_version("5.3")
+    trecquerysource = autoclass('org.terrier.applications.batchquerying.TRECQuery')
+    tqs = trecquerysource(
+        [file_path], doc_tag, id_tag, whitelist, blacklist,
+        # help jnius select the correct constructor 
+        signature="([Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;)V")
+    topics_lst=[]
+    while(tqs.hasNext()):
+        topic = tqs.next()
+        qid = tqs.getQueryId()
+        topics_lst.append([qid,topic])
+    topics_dt = pd.DataFrame(topics_lst,columns=['qid','query'])
+    return topics_dt
+
+def _read_topics_trecxml(filename, tags=["query", "question", "narrative"], tokenise=True):
+    """
+    Parse a file containing topics in TREC-like XML format
+
+    Args:
+        filename(str): The path to the topics file
+
+    Returns:
+        pandas.Dataframe with columns=['qid','query']
+    """
+    import xml.etree.ElementTree as ET
+    import pandas as pd
+    tags=set(tags)
+    topics=[]
+    tree = ET.parse(filename)
+    root = tree.getroot()
+    from jnius import autoclass
+    tokeniser = autoclass("org.terrier.indexing.tokenisation.Tokeniser").getTokeniser()
+    for child in root.iter('topic'):
+        qid = child.attrib["number"]
+        query = ""
+        for tag in child:
+            if tag.tag in tags:
+                query_text = tag.text
+                if tokenise:
+                    query_text = " ".join(tokeniser.getTokens(query_text))
+                query += " " + query_text
+        topics.append((str(qid), query)) 
+    return pd.DataFrame(topics, columns=["qid", "query"])
+
+def _read_topics_singleline(filepath, tokenise=True):
+    """
+    Parse a file containing topics, one per line
+
+    Args:
+        file_path(str): The path to the topics file
+        tokenise(bool): whether the query should be tokenised, using Terrier's standard Tokeniser.
+            If you are using matchop formatted topics, this should be set to False.
+
+    Returns:
+        pandas.Dataframe with columns=['qid','query']
+    """
+    rows = []
+    from jnius import autoclass
+    from . import check_version
+    assert check_version("5.3")
+    slqIter = autoclass("org.terrier.applications.batchquerying.SingleLineTRECQuery")(filepath, tokenise)
+    for q in slqIter:
+        rows.append([slqIter.getQueryId(), q])
+    return pd.DataFrame(rows, columns=["qid", "query"])
+
+def read_qrels(file_path):
+    """
+    Parse a file containing qrels
+
+    Args:
+        file_path(str): The path to the qrels file
+
+    Returns:
+        pandas.Dataframe with columns=['qid','docno', 'label']
+        with column types string, string, and int
+    """
+    df = pd.read_csv(file_path, sep=r'\s+', names=["qid", "iter", "docno", "label"])
+    df = df.drop(columns="iter")
+    df["qid"] = df["qid"].astype(str)
+    df["docno"] = df["docno"].astype(str)
+    return df

--- a/pyterrier/utils.py
+++ b/pyterrier/utils.py
@@ -2,7 +2,11 @@ import pandas as pd
 import pytrec_eval
 from collections import defaultdict
 import os
+import deprecation
 
+
+@deprecation.deprecated(deprecated_in="0.3.0",
+                        details="Please use pt.io.autopen()")
 def autoopen(filename, mode='rb'):
     if filename.endswith(".gz"):
         import gzip
@@ -15,6 +19,8 @@ def autoopen(filename, mode='rb'):
 class Utils:
 
     @staticmethod
+    @deprecation.deprecated(deprecated_in="0.3.0",
+                        details="Please use pt.io.write_results(res, filename, format='letor')")
     def write_results_letor(res, filename, qrels=None, default_label=0):
         if qrels is not None:
             res = res.merge(qrels, on=['qid', 'docno'], how='left').fillna(default_label)
@@ -26,6 +32,8 @@ class Utils:
                 f.write("%d qid:%s %s # docno=%s\n" % (label, row.qid, feat_str, row.docno))
     
     @staticmethod
+    @deprecation.deprecated(deprecated_in="0.3.0",
+                        details="Please use pt.io.write_results(res, filename, format='trec')")
     def write_results_trec(res, filename, run_name="pyterrier"):
         res_copy = res.copy()[["qid", "docno", "rank", "score"]]
         res_copy.insert(1, "Q0", "Q0")
@@ -33,15 +41,8 @@ class Utils:
         res_copy.to_csv(filename, sep=" ", header=False, index=False)
 
     @staticmethod
-    def parse_query_result(filename):
-        results = []
-        with open(filename, 'rt') as file:
-            for line in file:
-                split_line = line.strip("\n").split(" ")
-                results.append([split_line[1], float(split_line[2])])
-        return results
-
-    @staticmethod
+    @deprecation.deprecated(deprecated_in="0.3.0",
+                        details="Please use pt.io.read_results(filename, format='letor')")
     def parse_letor_results_file(filename, labels=False):
 
         def _parse_line(l):
@@ -84,6 +85,8 @@ class Utils:
             return pd.DataFrame(rows, columns=["qid", "docno", "features", "label"] if labels else ["qid", "docno", "features"])
 
     @staticmethod
+    @deprecation.deprecated(deprecated_in="0.3.0",
+                        details="Please use pt.io.read_results(filename, format='trec')")
     def parse_results_file(filename):
         results = []
         df = pd.read_csv(filename, sep=r'\s+', names=["qid", "iter", "docno", "rank", "score", "name"])
@@ -95,15 +98,8 @@ class Utils:
         return df
 
     @staticmethod
-    def parse_res_file(filename):
-        results = []
-        with open(filename, 'r') as file:
-            for line in file:
-                split_line = line.strip("\n").split(" ")
-                results.append([split_line[0], split_line[2], float(split_line[4])])
-        return results
-
-    @staticmethod
+    @deprecation.deprecated(deprecated_in="0.3.0",
+                        details="Please use pt.io.read_topics(filename, format='singleline')")
     def parse_singleline_topics_file(filepath, tokenise=True):
         """
         Parse a file containing topics, one per line
@@ -126,6 +122,8 @@ class Utils:
         return pd.DataFrame(rows, columns=["qid", "query"])
 
     @staticmethod
+    @deprecation.deprecated(deprecated_in="0.3.0",
+                        details="Please use pt.io.read_topics(filename, format='trec')")
     def parse_trec_topics_file(file_path, doc_tag="TOP", id_tag="NUM", whitelist=["TITLE"], blacklist=["DESC","NARR"]):
         """
         Parse a file containing topics in standard TREC format
@@ -154,6 +152,8 @@ class Utils:
         return topics_dt
 
     @staticmethod
+    @deprecation.deprecated(deprecated_in="0.3.0",
+                        details="Please use pt.io.read_topics(filename, format='trecxml')")
     def parse_trecxml_topics_file(filename, tags=["query", "question", "narrative"], tokenise=True):
         """
         Parse a file containing topics in TREC-like XML format
@@ -185,6 +185,8 @@ class Utils:
         return pd.DataFrame(topics, columns=["qid", "query"])
 
     @staticmethod
+    @deprecation.deprecated(deprecated_in="0.3.0",
+                        details="Please use pt.io.read_qrels(filename)")
     def parse_qrels(file_path):
         """
         Parse a file containing qrels
@@ -245,20 +247,14 @@ class Utils:
             metrics(list): A list of strings specifying which evaluation metrics to use. Default=['map', 'ndcg']
             perquery(bool): If true return each metric for each query, else return mean metrics. Default=False
         """
-        def now():
-            from datetime import datetime
-            return datetime.now().strftime("%H:%M:%S.%f")
-        #print(now() + " evaluate started")    
         if isinstance(res, pd.DataFrame):
             batch_retrieve_results_dict = Utils.convert_res_to_dict(res)
         else:
             batch_retrieve_results_dict = res
-        #print(now() + " res ready")
         if isinstance(qrels, pd.DataFrame):
             qrels_dic = Utils.convert_qrels_to_dict(qrels)
         else:
             qrels_dic = qrels
-        #print(now() + " qrels ready")
         req_metrics = set()
         cutdown = False
         for m in metrics:
@@ -272,9 +268,7 @@ class Utils:
 
         evaluator = pytrec_eval.RelevanceEvaluator(qrels_dic, req_metrics)
 
-        #print(now() + " evaluating")
         result = evaluator.evaluate(batch_retrieve_results_dict)
-        #print(now() + " evaluation done")
         if perquery:
             if not cutdown:
                 return result

--- a/tests/test_br.py
+++ b/tests/test_br.py
@@ -4,6 +4,22 @@ import os
 import unittest
 from .base import BaseTestCase
 
+def parse_res_file(filename):
+    results = []
+    with open(filename, 'r') as file:
+        for line in file:
+            split_line = line.strip("\n").split(" ")
+            results.append([split_line[0], split_line[2], float(split_line[4])])
+    return results
+
+def parse_query_result(filename):
+    results = []
+    with open(filename, 'rt') as file:
+        for line in file:
+            split_line = line.strip("\n").split(" ")
+            results.append([split_line[1], float(split_line[2])])
+    return results
+
 class TestBatchRetrieve(BaseTestCase):
 
     def test_form_dataframe_with_string(self):
@@ -78,7 +94,7 @@ class TestBatchRetrieve(BaseTestCase):
         for indexSrc in (indexloc, jindexref, jindex):
             retr = pt.BatchRetrieve(indexSrc)
             result = retr.transform("light")
-            exp_result = pt.Utils.parse_query_result(os.path.dirname(
+            exp_result = parse_query_result(os.path.dirname(
                 os.path.realpath(__file__)) + "/fixtures/light_results")
             for index, row in result.iterrows():
                 self.assertEqual(row['docno'], exp_result[index][0])
@@ -91,7 +107,7 @@ class TestBatchRetrieve(BaseTestCase):
         retr = pt.BatchRetrieve(indexref)
         input = pd.DataFrame([["1", "Stability"], ["2", "Generator"]], columns=['qid', 'query'])
         result = retr.transform(input)
-        exp_result = pt.Utils.parse_res_file(os.path.dirname(
+        exp_result = parse_res_file(os.path.dirname(
             os.path.realpath(__file__)) + "/fixtures/two_queries_result")
         for index, row in result.iterrows():
             self.assertEqual(row['qid'], exp_result[index][0])
@@ -100,7 +116,7 @@ class TestBatchRetrieve(BaseTestCase):
 
         input = pd.DataFrame([[1, "Stability"], [2, "Generator"]], columns=['qid', 'query'])
         result = retr.transform(input)
-        exp_result = pt.Utils.parse_res_file(os.path.dirname(
+        exp_result = parse_res_file(os.path.dirname(
             os.path.realpath(__file__)) + "/fixtures/two_queries_result")
         for index, row in result.iterrows():
             self.assertEqual(str(row['qid']), exp_result[index][0])

--- a/tests/test_fbr.py
+++ b/tests/test_fbr.py
@@ -35,8 +35,8 @@ class TestFeaturesBatchRetrieve(BaseTestCase):
         JIR = pt.autoclass('org.terrier.querying.IndexRef')
         indexref = JIR.of(self.here + "/fixtures/index/data.properties")
         retr = pt.FeaturesBatchRetrieve(indexref, ["WMODEL:PL2"])
-        topics = pt.Utils.parse_trec_topics_file(self.here + "/fixtures/vaswani_npl/query-text.trec").head(3)
-        qrels = pt.Utils.parse_qrels(self.here + "/fixtures/vaswani_npl/qrels")
+        topics = pt.io.read_topics(self.here + "/fixtures/vaswani_npl/query-text.trec").head(3)
+        qrels = pt.io.read_qrels(self.here + "/fixtures/vaswani_npl/qrels")
         res = retr.transform(topics)
         res = res.merge(qrels, on=['qid', 'docno'], how='left').fillna(0)
         from sklearn.ensemble import RandomForestClassifier

--- a/tests/test_ltr_pipelines.py
+++ b/tests/test_ltr_pipelines.py
@@ -17,8 +17,8 @@ class TestLTRPipeline(BaseTestCase):
             'random_state': 42
         }
 
-        topics = pt.Utils.parse_trec_topics_file(self.here + "/fixtures/vaswani_npl/query_light.trec").head(5)
-        qrels = pt.Utils.parse_qrels(self.here + "/fixtures/vaswani_npl/qrels")
+        topics = pt.io.read_topics(self.here + "/fixtures/vaswani_npl/query_light.trec").head(5)
+        qrels = pt.io.read_qrels(self.here + "/fixtures/vaswani_npl/qrels")
 
         pipeline = pt.FeaturesBatchRetrieve(self.here + "/fixtures/index/data.properties", ["WMODEL:PL2", "WMODEL:BM25"], controls={"wmodel" : "DPH"}) >> \
             pt.XGBoostLTR_pipeline(xgb.sklearn.XGBRanker(**xgparams))
@@ -32,8 +32,8 @@ class TestLTRPipeline(BaseTestCase):
     def test_ltr_pipeline(self):
         from sklearn.ensemble import RandomForestClassifier
 
-        topics = pt.Utils.parse_trec_topics_file(self.here + "/fixtures/vaswani_npl/query_light.trec").head(5)
-        qrels = pt.Utils.parse_qrels(self.here + "/fixtures/vaswani_npl/qrels")
+        topics = pt.io.read_topics(self.here + "/fixtures/vaswani_npl/query_light.trec").head(5)
+        qrels = pt.io.read_qrels(self.here + "/fixtures/vaswani_npl/qrels")
 
         pipeline = pt.FeaturesBatchRetrieve(self.here + "/fixtures/index/data.properties", ["WMODEL:PL2", "WMODEL:BM25"], controls={"wmodel" : "DPH"}) >> \
             pt.LTR_pipeline(RandomForestClassifier())

--- a/tests/test_topicsparsing.py
+++ b/tests/test_topicsparsing.py
@@ -7,8 +7,8 @@ import pandas as pd
 class TestTopicsParsing(BaseTestCase):
 
     def testSingleLine(self):
-        topics = pt.Utils.parse_singleline_topics_file(
-            os.path.dirname(os.path.realpath(__file__)) + "/fixtures/singleline.topics")
+        topics = pt.io.read_topics(
+            os.path.dirname(os.path.realpath(__file__)) + "/fixtures/singleline.topics", format="singleline")
         self.assertEqual(2, len(topics))
         self.assertTrue("qid" in topics.columns)
         self.assertTrue("query" in topics.columns)
@@ -20,11 +20,11 @@ class TestTopicsParsing(BaseTestCase):
     def test_parse_trec_topics_file_T(self):
         input = os.path.dirname(os.path.realpath(__file__)) + "/fixtures/topics.trec"
         exp_result = pd.DataFrame([["1", "light"], ["2", "radiowave"], ["3", "sound"]], columns=['qid', 'query'])
-        result = pt.Utils.parse_trec_topics_file(input)
+        result = pt.io.read_topics(input)
         self.assertTrue(exp_result.equals(result))
 
     def test_parse_trec_topics_file_D(self):
         input = os.path.dirname(os.path.realpath(__file__)) + "/fixtures/topics.trec"
         exp_result = pd.DataFrame([["1", "lights"], ["2", "radiowaves"], ["3", "sounds"]], columns=['qid', 'query'])
-        result = pt.Utils.parse_trec_topics_file(input, whitelist=["DESC"], blacklist=["TITLE"])
+        result = pt.io.read_topics(input, format="trec", whitelist=["DESC"], blacklist=["TITLE"])
         self.assertTrue(exp_result.equals(result))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,8 +21,8 @@ class TestUtils(BaseTestCase):
         res_dict = res.set_index(['qid', 'docno']).to_dict()
         for filename in ["rtr.res", "rtr.res.gz", "rtr.res.bz2"]:
             filepath = os.path.join(self.test_dir, filename)
-            pt.Utils.write_results_trec(res, filepath)
-            res2 = pt.Utils.parse_results_file(filepath)
+            pt.io.write_results(res, filepath, format="trec")
+            res2 = pt.io.read_results(filepath)
             res2_dict = res2.set_index(['qid', 'docno']).to_dict()
             del res2_dict["name"]
             self.assertEqual(res_dict, res2_dict)
@@ -35,8 +35,8 @@ class TestUtils(BaseTestCase):
         del res_dict["rank"]
         for filename in ["rtr.letor", "rtr.letor.gz", "rtr.letor.bz2"]:
             filepath = os.path.join(self.test_dir, filename)
-            pt.Utils.write_results_letor(res, filepath)
-            res2 = pt.Utils.parse_letor_results_file(filepath)
+            pt.io.write_results(res, filepath, format="letor")
+            res2 = pt.io.read_results(filepath, format="letor")
 
             for ((i1, row1), (i2, row2)) in zip(res.iterrows(), res2.iterrows()):
                 self.assertEqual(row1["qid"], row2["qid"])
@@ -60,7 +60,7 @@ class TestUtils(BaseTestCase):
     def test_parse_qrels(self):
         input = os.path.dirname(os.path.realpath(__file__)) + "/fixtures/qrels"
         exp_result = pd.DataFrame([["1", "13", 1], ["1", "15", 1], ["2", "8", 1], ["2", "4", 1], ["2", "17", 1], ["3", "2", 1]], columns=['qid', 'docno', 'label'])
-        result = pt.Utils.parse_qrels(input)
+        result = pt.io.read_qrels(input)
         #print(exp_result)
         #print(result)
         pd.testing.assert_frame_equal(exp_result, result)
@@ -68,7 +68,7 @@ class TestUtils(BaseTestCase):
     def test_convert_qrels_to_dict(self):
         input = os.path.dirname(os.path.realpath(__file__)) + "/fixtures/qrels"
         exp_result = {"1": {"13": 1, "15": 1}, "2": {"17": 1, "8": 1, "4": 1}, "3": {"2": 1}}
-        df = pt.Utils.parse_qrels(input)
+        df = pt.io.read_qrels(input)
         result = dict(pt.Utils.convert_qrels_to_dict(df))
         self.assertEqual(exp_result, result)
 


### PR DESCRIPTION
Creates a new modules called io, which contains:
 - read_topics
 - read_qrels
 - read_results & write_results

These methods variously support various formats, for instance:
 - read_topics supports "trec", "trecxml", "singleline" 
 - read_results & write_results support "trec" and "letor"