### PR TITLE
ir_datasets integration #90

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ pt.Experiment([BM25_br, PL2_br], topics, qrels, eval_metrics)
 
 You can use `pt.datasets.list_datasets()` to see available test collections - if your favourite test collection is missing, [you can submit a Pull Request](https://github.com/terrier-org/pyterrier/pulls).
 
+All datasets from the [ir_datasts package](https://github.com/allenai/ir_datasets) are available
+under the `irds:` prefix. E.g., use `pt.datasets.get_dataset("irds:medline/2004/trec-genomics-2004")`
+to get the TREC Genomics 2004 dataset. A full catalogue of ir_datasets is available [here](https://ir-datasets.com/all.html).
+
 # Index API
 
 All of the standard Terrier Index API can be access easily from Pyterrier. 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ qrels = pt.datasets.get_dataset("trec-robust-2004").get_qrels()
 pt.Experiment([BM25_br, PL2_br], topics, qrels, eval_metrics)
 ```
 
+You can index datasets that include a corpus using IterDictIndexer and get_corpus_iter:
+
+```python
+dataset = pt.datasets.get_dataset('irds:cord19/trec-covid')
+indexer = pt.index.IterDictIndexer('./cord19-index')
+index_ref = indexer.index(dataset.get_corpus_iter(), fields=('title', 'abstract'))
+```
+
 You can use `pt.datasets.list_datasets()` to see available test collections - if your favourite test collection is missing, [you can submit a Pull Request](https://github.com/terrier-org/pyterrier/pulls).
 
 All datasets from the [ir_datasets package](https://github.com/allenai/ir_datasets) are available

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ pt.Experiment([BM25_br, PL2_br], topics, qrels, eval_metrics)
 
 You can use `pt.datasets.list_datasets()` to see available test collections - if your favourite test collection is missing, [you can submit a Pull Request](https://github.com/terrier-org/pyterrier/pulls).
 
-All datasets from the [ir_datasts package](https://github.com/allenai/ir_datasets) are available
+All datasets from the [ir_datasets package](https://github.com/allenai/ir_datasets) are available
 under the `irds:` prefix. E.g., use `pt.datasets.get_dataset("irds:medline/2004/trec-genomics-2004")`
 to get the TREC Genomics 2004 dataset. A full catalogue of ir_datasets is available [here](https://ir-datasets.com/all.html).
 

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -21,6 +21,8 @@ Available Datasets
 
 The table below lists the provided datasets, detailing the attributes available for each dataset.
 In each column, True designates the presence of a single artefact of that type, while a list denotes the available variants.
+Datasets with the ``irds:`` prefix are from the `ir_datasets package <https://github.com/allenai/ir_datasets>`_; further
+documentation on these datasets can be found `here <https://ir-datasets.com/all.html>`_.
 
 .. include:: ./_includes/datasets-list-inc.rst
 

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -49,9 +49,10 @@ Indexing and then retrieval of documents from the `MSMARCO document corpus <http
     indexer = pt.TRECCollectionIndexer("./index")
     # this downloads the file msmarco-docs.trec.gz 
     indexref = indexer.index(dataset.get_corpus())
+    index = pt.IndexFactory.of(indexref)
 
     DPH_br = pt.BatchRetrieve(index, wmodel="DPH") % 100
-    BM25_br = pt.BatchRetrieve(index, wmodel="DPH") % 100
+    BM25_br = pt.BatchRetrieve(index, wmodel="BM25") % 100
     # this runs an experiment to obtain results on the TREC 2019 Deep Learning track queries and qrels
     pt.Experiment(
         [DPH_br, BM25_br], 
@@ -60,3 +61,19 @@ Indexing and then retrieval of documents from the `MSMARCO document corpus <http
         eval_metrics=["recip_rank", "ndcg_cut_10", "map"])
 
 For more details on use of MSMARCO, see `our MSMARCO leaderboard submission notebooks <https://github.com/cmacdonald/pyterrier-msmarco-document-leaderboard-runs>`_.
+
+You can also index datasets that include a corpus using IterDictIndexer and get_corpus_iter::
+
+    dataset = pt.datasets.get_dataset('irds:cord19/trec-covid')
+    indexer = pt.index.IterDictIndexer('./cord19-index')
+    indexref = indexer.index(dataset.get_corpus_iter(), fields=('title', 'abstract'))
+    index = pt.IndexFactory.of(indexref)
+
+    DPH_br = pt.BatchRetrieve(index, wmodel="DPH") % 100
+    BM25_br = pt.BatchRetrieve(index, wmodel="BM25") % 100
+    # this runs an experiment to obtain results on the TREC COVID queries and qrels
+    pt.Experiment(
+        [DPH_br, BM25_br], 
+        dataset.get_topics('title'), 
+        dataset.get_qrels(), 
+        eval_metrics=["P.5", "P.10", "ndcg_cut.10", "map"])

--- a/docs/extras/generate_includes.py
+++ b/docs/extras/generate_includes.py
@@ -28,7 +28,7 @@ def dataset_include():
     df = fix_width(df, "qrels")
     df = fix_width(df, "topics")
     df = fix_width(df, "corpus")
-    df = df[["dataset", "corpus", "index", "topics", "qrels"]]
+    df = df[["dataset", "corpus", "index", "topics", "qrels", "info_url"]]
     table = df.set_index('dataset').to_markdown(tablefmt="rst")
 
     with open("_includes/datasets-list-inc.rst", "wt") as f:

--- a/pyterrier/datasets.py
+++ b/pyterrier/datasets.py
@@ -48,7 +48,7 @@ class Dataset():
         """
             Returns the ISO 639-1 language code for the corpus, or None for multiple/other/unknown
         """
-        pass
+        return None
 
     def get_index(self, variant=None):
         """ 
@@ -66,7 +66,7 @@ class Dataset():
         """
             Returns the ISO 639-1 language code for the topics, or None for multiple/other/unknown
         """
-        pass
+        return None
 
     def get_qrels(self, variant=None):
         """ 
@@ -78,7 +78,7 @@ class Dataset():
         """
             Returns a url that provides more information about this dataset.
         """
-        pass
+        return None
 
 class RemoteDataset(Dataset):
 
@@ -247,6 +247,9 @@ class RemoteDataset(Dataset):
     def __repr__(self):
         return "RemoteDataset for %s, with %s" % (self.name, str(list(self.locations.keys())))
 
+    def info_url(self):
+        return self.locations['info_url'] if "info_url" in self.locations else None
+
 
 class IRDSDataset(Dataset):
     def __init__(self, irds_id):
@@ -382,6 +385,7 @@ ANTIQUE_FILES = {
     },
     "corpus" : 
         [("antique-collection.txt", "http://ciir.cs.umass.edu/downloads/Antique/antique-collection.txt")],
+    "info_url" : "https://ciir.cs.umass.edu/downloads/Antique/readme.txt",
 }
 
 TREC_COVID_FILES = {
@@ -410,6 +414,7 @@ TREC_COVID_FILES = {
         "docids-rnd4" : ("docids-rnd4.txt", "https://ir.nist.gov/covidSubmit/data/docids-rnd4.txt"),
         "docids-rnd5" : ("docids-rnd5.txt", "https://ir.nist.gov/covidSubmit/data/docids-rnd5.txt")
     },
+    "info_url"  : "https://ir.nist.gov/covidSubmit/"
 }
 
 TREC_DEEPLEARNING_DOCS_MSMARCO_FILES = {
@@ -430,7 +435,8 @@ TREC_DEEPLEARNING_DOCS_MSMARCO_FILES = {
             "train" : ("msmarco-doctrain-qrels.tsv.gz", "https://msmarco.blob.core.windows.net/msmarcoranking/msmarco-doctrain-qrels.tsv.gz"),
             "dev" : ("msmarco-docdev-qrels.tsv.gz", "https://msmarco.blob.core.windows.net/msmarcoranking/msmarco-docdev-qrels.tsv.gz"),
             "test" : ("2019qrels-docs.txt", "https://trec.nist.gov/data/deep/2019qrels-docs.txt")
-        }
+        },
+    "info_url" : "https://microsoft.github.io/msmarco/",
 }
 
 TREC_DEEPLEARNING_PASSAGE_MSMARCO_FILES = {
@@ -452,7 +458,8 @@ TREC_DEEPLEARNING_PASSAGE_MSMARCO_FILES = {
             "train" : ("qrels.train.tsv", "https://msmarco.blob.core.windows.net/msmarcoranking/qrels.train.tsv"),
             "dev" : ("qrels.dev.tsv", "https://msmarco.blob.core.windows.net/msmarcoranking/qrels.dev.tsv"),
             "test-2019" : ("2019qrels-docs.txt", "https://trec.nist.gov/data/deep/2019qrels-pass.txt")
-        }
+        },
+    "info_url" : "https://microsoft.github.io/MSMARCO-Passage-Ranking/",
 }
 
 # remove WT- prefix from topics
@@ -489,7 +496,8 @@ TREC_WT_2002_FILES = {
         { 
             "np" : ("qrels.named-page.txt.gz", "https://trec.nist.gov/data/qrels_eng/qrels.named-page.txt.gz"),
             "td" : ("qrels.distillation.txt.gz", "https://trec.nist.gov/data/qrels_eng/qrels.distillation.txt.gz")
-        }
+        },
+    "info_url" : "https://trec.nist.gov/data/t11.web.html",
 }
 
 TREC_WT_2003_FILES = {
@@ -502,7 +510,8 @@ TREC_WT_2003_FILES = {
         { 
             "np" : ("qrels.named-page.txt.gz", "https://trec.nist.gov/data/qrels_eng/qrels.named-page.txt.gz"),
             "td" : ("qrels.distillation.2003.txt", "https://trec.nist.gov/data/qrels_eng/qrels.distillation.2003.txt")
-        }
+        },
+    "info_url" : "https://trec.nist.gov/data/t12.web.html",
 }
 
 def filter_on_qid_type(self, component, variant):
@@ -536,7 +545,8 @@ TREC_WT_2004_FILES = {
             "td" : filter_on_qid_type,
             "np" : filter_on_qid_type,
             "all" : ("04.qrels.web.mixed.txt", "https://trec.nist.gov/data/web/04.qrels.web.mixed.txt")
-        }
+        },
+    "info_url" : "https://trec.nist.gov/data/t13.web.html",
 }
 
 FIFTY_PCT_INDEX_BASE = "http://www.dcs.gla.ac.uk/~craigm/IR_HM/"
@@ -580,7 +590,8 @@ TREC_WT_2009_FILES = {
         "adhoc" : ("prels.1-50.gz", "https://trec.nist.gov/data/web/09/prels.1-50.gz"),
         "adhoc.catA" : ("prels.catA.1-50.gz", "https://trec.nist.gov/data/web/09/prels.catA.1-50.gz"),
         "adhoc.catB" : ("prels.catB.1-50.gz", "https://trec.nist.gov/data/web/09/prels.catB.1-50.gz")
-    }
+    },
+    "info_url" : "https://trec.nist.gov/data/web09.html",
 }
 
 TREC_WT_2010_FILES = {
@@ -590,7 +601,8 @@ TREC_WT_2010_FILES = {
     "qrels" : 
         { 
             "adhoc" : ("qrels.adhoc", "https://trec.nist.gov/data/web/10/10.adhoc-qrels.final")
-        }
+        },
+    "info_url" : "https://trec.nist.gov/data/web10.html",
 }
 
 TREC_WT_2011_FILES = {
@@ -610,12 +622,14 @@ TREC_WT_2012_FILES = {
     "qrels" : 
         { 
             "adhoc" : ("qrels.adhoc", "https://trec.nist.gov/data/web/12/qrels.adhoc")
-        }
+        },
+    "info_url" : "https://trec.nist.gov/data/web2011.html",
 }
 
 TREC_WT2G_FILES = {
     "qrels" : [ ("qrels.trec8.small_web.gz", "https://trec.nist.gov/data/qrels_eng/qrels.trec8.small_web.gz") ],
-    "topics" : [ (  "topics.401-450.gz", "https://trec.nist.gov/data/topics_eng/topics.401-450.gz" ) ]
+    "topics" : [ (  "topics.401-450.gz", "https://trec.nist.gov/data/topics_eng/topics.401-450.gz" ) ],
+    "info_url" : "https://trec.nist.gov/data/t8.web.html",
 }
 
 TREC_WT10G_FILES = {
@@ -632,6 +646,7 @@ TREC_WT10G_FILES = {
     "topics_desc_only" : {
          "trec10-hp" : (  "entry_page_topics.1-145.txt", "https://trec.nist.gov/data/topics_eng/entry_page_topics.1-145.txt" ),
     },
+    "info_url" : "https://trec.nist.gov/data/t9.web.html",
 }
 
 def _merge_years(self, component, variant):
@@ -665,16 +680,19 @@ TREC_TB_FILES = {
 
         "2005-np" : ( "05.np_qrels", "https://trec.nist.gov/data/terabyte/05/05.np_qrels"),
         "2006-np" : ( "qrels.tb06.np", "https://trec.nist.gov/data/terabyte/06/qrels.tb06.np"),
-    }
+    },
+    "info_url" : "https://trec.nist.gov/data/terabyte.html"
 }
 
 TREC_ROBUST_04_FILES = {
     "qrels" : [ ("qrels.robust2004.txt", "https://trec.nist.gov/data/robust/qrels.robust2004.txt") ],
-    "topics" : [ (  "04.testset.gz", "https://trec.nist.gov/data/robust/04.testset.gz" ) ]
+    "topics" : [ (  "04.testset.gz", "https://trec.nist.gov/data/robust/04.testset.gz" ) ],
+    "info_url" : "https://trec.nist.gov/data/t13_robust.html",
 }
 TREC_ROBUST_05_FILES = {
     "qrels" : [ ("TREC2005.qrels.txt", "https://trec.nist.gov/data/robust/05/TREC2005.qrels.txt") ],
-    "topics" : [ (  "05.50.topics.txt", "https://trec.nist.gov/data/robust/05/05.50.topics.txt" ) ]
+    "topics" : [ (  "05.50.topics.txt", "https://trec.nist.gov/data/robust/05/05.50.topics.txt" ) ],
+    "info_url" : "https://trec.nist.gov/data/t14_robust.html",
 }
 
 TREC_PRECISION_MEDICINE_FILES = {
@@ -696,7 +714,8 @@ TREC_PRECISION_MEDICINE_FILES = {
         "qrels-2019-trials" : ("qrels-2019-trials.txt", "https://trec.nist.gov/data/precmed/qrels-treceval-trials.38.txt"),
         "qrels-2019-abstracts-sample" : ("qrels-2019-abstracts-sample.txt", "https://trec.nist.gov/data/precmed/qrels-sampleval-abstracts.2019.txt"),
         "qrels-2019-trials-sample" : ("qrels-2019-trials-sample.txt", "https://trec.nist.gov/data/precmed/qrels-sampleval-trials.38.txt")
-    }
+    },
+    "info_url" : "https://trec.nist.gov/data/precmed.html",
 }
 
 VASWANI_CORPUS_BASE = "https://raw.githubusercontent.com/terrier-org/pyterrier/master/tests/fixtures/vaswani_npl/"
@@ -709,7 +728,8 @@ VASWANI_FILES = {
     "qrels":
         [("qrels", VASWANI_CORPUS_BASE + "qrels")],
     "index":
-        [(filename, VASWANI_INDEX_BASE + filename) for filename in STANDARD_TERRIER_INDEX_FILES + ["data.meta-0.fsomapfile"]]
+        [(filename, VASWANI_INDEX_BASE + filename) for filename in STANDARD_TERRIER_INDEX_FILES + ["data.meta-0.fsomapfile"]],
+    "info_url" : "http://ir.dcs.gla.ac.uk/resources/test_collections/npl/",
 }
 
 DATASET_MAP = {

--- a/pyterrier/datasets.py
+++ b/pyterrier/datasets.py
@@ -227,10 +227,13 @@ class IRDSDataset(Dataset):
     def get_corpus(self):
         raise NotImplementedError("IRDSDataset doesn't support get_corpus; use get_corpus_iter instead")
 
-    def get_corpus_iter(self):
+    def get_corpus_iter(self, verbose=True):
         ds = self.irds_ref()
         assert ds.has_docs(), f"{self._irds_id} doesn't support get_corpus_iter"
-        for doc in ds.docs_iter():
+        it = ds.docs_iter()
+        if verbose:
+            it = tqdm(it, desc=f'{self._irds_id} documents', total=ds.docs_count())
+        for doc in it:
             doc = doc._asdict()
             # pyterrier uses "docno"
             doc['docno'] = doc.pop('doc_id')
@@ -304,7 +307,7 @@ class IRDSDataset(Dataset):
             return None
         if component == "qrels":
             if ds.has_qrels():
-                fields = [f for f in ds.qrels_cls()._fields if f not in ('qurey_id', 'doc_id', 'iteration')]
+                fields = [f for f in ds.qrels_cls()._fields if f not in ('query_id', 'doc_id', 'iteration')]
                 if len(fields) > 1:
                     return list(fields)
                 return True

--- a/pyterrier/datasets.py
+++ b/pyterrier/datasets.py
@@ -38,6 +38,12 @@ class Dataset():
         """
         pass
 
+    def get_corpus_iter(self, verbose=True):
+        """
+            Returns an iter of dicts for this collection. If verbose=True, a tqdm pbar shows the progress over this iterator.
+        """
+        pass
+
     def get_index(self, variant=None):
         """ 
             Returns the IndexRef of the index to allow retrieval. Only a few datasets provide indices ready made.
@@ -53,6 +59,12 @@ class Dataset():
     def get_qrels(self, variant=None):
         """ 
             Returns the qrels, as a dataframe, ready for evaluation.
+        """
+        pass
+
+    def info_url(self):
+        """
+            Returns a url that provides more information about this dataset.
         """
         pass
 
@@ -315,6 +327,11 @@ class IRDSDataset(Dataset):
         if component == "corpus":
             return ds.has_docs() or None
         return None
+
+    def info_url(self):
+        top_id = self._irds_id.split('/', 1)[0]
+        suffix = f'#{self._irds_id}' if top_id != self._irds_id else ''
+        return f'https://ir-datasets.com/{top_id}.html{suffix}'
 
     def __repr__(self):
         return f"IRDSDataset({repr(self._irds_id)})"
@@ -731,5 +748,6 @@ def list_datasets():
             dataset._describe_component("topics"), 
             dataset._describe_component("qrels"), 
             dataset._describe_component("corpus"), 
-            dataset._describe_component("index") ])
-    return pd.DataFrame(rows, columns=["dataset", "topics", "qrels", "corpus", "index"])
+            dataset._describe_component("index"),
+            dataset.info_url() ])
+    return pd.DataFrame(rows, columns=["dataset", "topics", "qrels", "corpus", "index", "info_url"])

--- a/pyterrier/datasets.py
+++ b/pyterrier/datasets.py
@@ -743,7 +743,6 @@ TREC_PRECISION_MEDICINE_FILES = {
     "info_url" : "https://trec.nist.gov/data/precmed.html",
 }
 
-def trec2text(dataset):
 
 
 VASWANI_CORPUS_BASE = "https://raw.githubusercontent.com/terrier-org/pyterrier/master/tests/fixtures/vaswani_npl/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ nptyping
 tabulate
 jinja2
 ir_datasets>=0.2.0
+sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ requests
 nptyping
 tabulate
 jinja2
-ir_datasets>=0.1.7
+ir_datasets>=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ requests
 nptyping
 tabulate
 jinja2
+ir_datasets>=0.1.7

--- a/tests/test_irds_integration.py
+++ b/tests/test_irds_integration.py
@@ -26,23 +26,24 @@ class TestIrDatasetsIntegration(BaseTestCase):
                 self.assertEqual(index.lexicon['bit'].frequency, 33)
 
     def test_cord19(self):
-        dataset = pt.datasets.get_dataset('irds:cord19/trec-covid')
-        with self.subTest('topics'):
-            topics = dataset.get_topics()
-            self.assertEqual(len(topics), 50)
-        with self.subTest('qrels'):
-            qrels = dataset.get_qrels()
-            self.assertEqual(len(qrels), 69318)
-        with self.subTest('corpus'):
-            corpus = dataset.get_corpus_iter()
-            corpus = list(corpus)
-            self.assertEqual(len(corpus), 192509)
-        with self.subTest('indexing'):
-            with tempfile.TemporaryDirectory() as d:
-                indexer = pt.index.IterDictIndexer(d)
-                indexref = indexer.index(dataset.get_corpus_iter(), fields=('title', 'abstract'))
-                index = pt.IndexFactory.of(indexref)
-                self.assertEqual(index.lexicon['covid'].frequency, 200582)
+        if "PYTERRIER_TEST_IRDS_CORD" in os.environ:
+            dataset = pt.datasets.get_dataset('irds:cord19/trec-covid')
+            with self.subTest('topics'):
+                topics = dataset.get_topics()
+                self.assertEqual(len(topics), 50)
+            with self.subTest('qrels'):
+                qrels = dataset.get_qrels()
+                self.assertEqual(len(qrels), 69318)
+            with self.subTest('corpus'):
+                corpus = dataset.get_corpus_iter()
+                corpus = list(corpus)
+                self.assertEqual(len(corpus), 192509)
+            with self.subTest('indexing'):
+                with tempfile.TemporaryDirectory() as d:
+                    indexer = pt.index.IterDictIndexer(d)
+                    indexref = indexer.index(dataset.get_corpus_iter(), fields=('title', 'abstract'))
+                    index = pt.IndexFactory.of(indexref)
+                    self.assertEqual(index.lexicon['covid'].frequency, 200582)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_irds_integration.py
+++ b/tests/test_irds_integration.py
@@ -1,0 +1,48 @@
+import pyterrier as pt
+import tempfile
+import unittest
+from .base import BaseTestCase
+import os
+import pandas as pd
+
+class TestIrDatasetsIntegration(BaseTestCase):
+
+    def test_vaswani(self):
+        dataset = pt.datasets.get_dataset('irds:vaswani')
+        with self.subTest('topics'):
+            topics = dataset.get_topics()
+            self.assertEqual(len(topics), 93)
+        with self.subTest('qrels'):
+            qrels = dataset.get_qrels()
+            self.assertEqual(len(qrels), 2083)
+        with self.subTest('corpus'):
+            corpus = dataset.get_corpus_iter()
+            corpus = list(corpus)
+            self.assertEqual(len(corpus), 11429)
+            with tempfile.TemporaryDirectory() as d:
+                indexer = pt.index.IterDictIndexer(d)
+                indexref = indexer.index(dataset.get_corpus_iter(), fields=('text',))
+                index = pt.IndexFactory.of(indexref)
+                self.assertEqual(index.lexicon['bit'].frequency, 33)
+
+    def test_cord19(self):
+        dataset = pt.datasets.get_dataset('irds:cord19/trec-covid')
+        with self.subTest('topics'):
+            topics = dataset.get_topics()
+            self.assertEqual(len(topics), 50)
+        with self.subTest('qrels'):
+            qrels = dataset.get_qrels()
+            self.assertEqual(len(qrels), 69318)
+        with self.subTest('corpus'):
+            corpus = dataset.get_corpus_iter()
+            corpus = list(corpus)
+            self.assertEqual(len(corpus), 192509)
+        with self.subTest('indexing'):
+            with tempfile.TemporaryDirectory() as d:
+                indexer = pt.index.IterDictIndexer(d)
+                indexref = indexer.index(dataset.get_corpus_iter(), fields=('title', 'abstract'))
+                index = pt.IndexFactory.of(indexref)
+                self.assertEqual(index.lexicon['covid'].frequency, 200582)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added `IRDSDataset` and populated it with everything available in ir_datasets (with `irds:` prefix).

I used the "variant" mechanism to select which fields to use, particularly for topics. (E.g., some topics have title, description, narrative fields, `get_topics(variant=)` selects which one.)

I added a `get_corpus_iter()` function that returns an iterator over document dicts (verbose=False disables a default tqdm bar). This can be used by IterDictIndexer:

```
>>> import pyterrier as pt
>>> pt.init()
>>> dataset = pt.datasets.get_dataset('irds:cord19')
>>> indexer = pt.index.IterDictIndexer('./cord19')
>>> indexer.index(dataset.get_corpus_iter(), fields=('title', 'abstract'))
[INFO] [starting] https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/historical_releases/cord-19_2020-07-16.tar.gz
[INFO] [finished] https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/historical_releases/cord-19_2020-07-16.tar.gz: [03:26] [3.66GB] [17.8MB/s]
[INFO] [starting] building docstore                                                                                                      
[INFO] [starting] extracting tarfile
[INFO] [finished] extracting tarfile [6.71s]
docs_iter: 192509it [00:11, 16264.41it/s]
[INFO] [finished] docs_iter: [00:11] [192509it] [16264.34it/s]
[INFO] [finished] building docstore [11.84s]
cord19 documents: 100%|████████████████████████████████████████████| 192509/192509 [01:06<00:00, 2899.25it/s]
14:56:39.186 [main] WARN  o.t.structures.indexing.Indexer - Indexed 60 empty documents
<org.terrier.querying.IndexRef at 0x7f3bde33a230 jclass=org/terrier/querying/IndexRef jself=<LocalRef obj=0x55b9e1313e50 at 0x7f3bde2b2270>>
>>> idx = pt.IndexFactory.of(pt.IndexRef.of(indexer.path))
>>> idx.lexicon['covid'].frequency
200582
```