### PR TITLE
Update pandas version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-pandas
+pandas>=0.25.0
 wget
 pytrec_eval>=0.5
 tqdm


### PR DESCRIPTION
There is a bug in Pandas < 0.25.0 that adds the string "None" as a suffix to column names on merging. That impacts pipelines such as those using `CombSumTransformer`, causing an error on searching columns such as "score" (because it became "scoreNone" instead).

Issue describing the error: 
https://github.com/pandas-dev/pandas/issues/24782

```python
>>> result = df.merge(df, left_index=True, right_index=True, suffixes=(None,'_dup'))
>>> result
   0None  0_dup
0      1      1
>>> result.columns
Index(['0None', '0_dup'], dtype='object')
```

There is also the possibility of other recent versions (current is 1.2.4), I'm using the 1.0.1 and it looks fine for now.