### PR TITLE
dynamic allocation of IRDSDataset

### DIFF
--- a/pyterrier/datasets.py
+++ b/pyterrier/datasets.py
@@ -844,6 +844,12 @@ def get_dataset(name, **kwargs):
     """
         Get a dataset by name
     """
+    # Some datasets in ir_datasets are built on-the-fly (e.g., clirmatrix).
+    # Handle this by allocating it on demand here.
+    if name not in DATASET_MAP and name.startswith('irds:'):
+        # remove irds: prefix
+        ds_id = name[len('irds:'):]
+        DATASET_MAP[name] = IRDSDataset(ds_id)
     rtr = DATASET_MAP[name]
     rtr._configure(**kwargs)
     return rtr


### PR DESCRIPTION
Background: [CLIRMatrix](https://www.aclweb.org/anthology/2020.emnlp-main.340/) is [being added to ir_datasets](https://github.com/ssun32/ir_datasets), which contains over 100k sub-datasets. There are so many due to the large number of language combinations. Rather than allocating all of them in the registry (which would be expensive to do every time the library is loaded), we're introducing a "pattern matching" approach that builds them on-the-fly, as they are requested. Thus, not all datasets will appear directly in the registry anymore, which means that they would not be available in pyterrier without a change like this one.