### PR TITLE
only compute ranks for score column

### DIFF
--- a/pyterrier/model.py
+++ b/pyterrier/model.py
@@ -24,7 +24,7 @@ def add_ranks(rtr : pd.DataFrame) -> pd.DataFrame:
         return rtr
 
     # -1 assures that first rank will be FIRST_RANK
-    rtr["rank"] = rtr.groupby("qid", sort=False).rank(ascending=False, method="first")["score"].astype(int) -1 + FIRST_RANK
+    rtr["rank"] = rtr.groupby("qid", sort=False)["score"].rank(ascending=False, method="first").astype(int) -1 + FIRST_RANK
     if STRICT_SORT:
         rtr.sort_values(["qid", "rank"], ascending=[True,True], inplace=True)
     return rtr


### PR DESCRIPTION
A bit of background: When `rank` is called for a full dataframe, it computes the ranks for every column. This is a bit of a waste because there's no need to have the ranks of other columns, e.g., docno, as they are immediately discarded. What's worse is that it can throw errors when columns exist in the dataframe that are not sortable, such as tensors.

`rank` can also be called on a series, so that's exactly what I change it to do.