### PR TITLE
using chunked instead of ichunked

### DIFF
--- a/pyterrier/transformer.py
+++ b/pyterrier/transformer.py
@@ -824,7 +824,7 @@ class ComposedPipeline(NAryTransformerBase):
     name = "Compose"
 
     def index(self, iter : Iterable[dict], batch_size=100):
-        from more_itertools import ichunked
+        from more_itertools import chunked
         
         if len(self.models) > 2:
             #this compose could have > 2 models. we need a composite transform() on all but the last
@@ -834,7 +834,7 @@ class ComposedPipeline(NAryTransformerBase):
         last_transformer = self.models[-1]
         
         def gen():
-            for batch in ichunked(iter, batch_size):
+            for batch in chunked(iter, batch_size):
                 batch_df = prev_transformer.transform_iter(batch)
                 for row in batch_df.itertuples(index=False):
                     yield row._asdict()


### PR DESCRIPTION
I noticed some unexpectedly poor performance in indexing pipelines (sometimes even resulted in segfaults?!?!). Tracked it down to the use of [`more_itertools.ichunked`](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.ichunked) in `index`. Replacing the function with [`more_itertools.chunked`](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.chunked) fixes the issue.

Unlike some `i`-prefixed iterable functions in the standard library, `ichunked` and `chunked` both return iterables; it's just that `ichunked` returns an `iter[list]` whereas `ichunked` returns an `iter[iter]`. To support this, `iterchunked` uses `tee`-ing so it can yield one version of the iterable and hold on to the other for itself. I bet this is where the problem arises.

In our case, we don't need an `iter[iter]` -- it usually just ends up being coerced into a DataFrame. And in cases where it doesn't, I also wouldn't expect problems because `batch_size` is likely always going to be a manageable size.

In a benchmark on `msmarco-passage`, I saw ~40x faster iteration.

A simple test using `more_itertools` alone clearly demonstrates the issue:

```python
>>> from tqdm import tqdm
>>> from more_itertools import chunked, ichunked
>>> for _ in ichunked(tqdm(range(3_000_000)), 1000):
...   pass
 23%|  698461/3000000 [00:05<00:36, 63231.90it/s]
 32%|  948724/3000000 [00:10<00:48, 42513.00it/s]
 38%| 1137833/3000000 [00:15<00:55, 33747.15it/s]
 43%| 1287378/3000000 [00:20<00:59, 28855.96it/s]
 48%| 1425604/3000000 [00:25<01:01, 25466.22it/s]
 51%| 1539932/3000000 [00:30<01:02, 23219.40it/s]
 55%| 1652571/3000000 [00:35<01:05, 20458.89it/s]
 58%| 1751094/3000000 [00:40<01:02, 19879.07it/s]
 62%| 1847406/3000000 [00:45<01:01, 18642.17it/s]
 65%| 1938015/3000000 [00:50<01:00, 17611.84it/s]
 68%| 2040571/3000000 [00:55<00:57, 16569.79it/s]
 70%| 2113594/3000000 [01:00<00:55, 15867.30it/s]
# ^ getting progressively slower over time

>>> for _ in chunked(tqdm(range(3_000_000)), 1000):
...   pass
100%| 3000000/3000000 [00:00<00:00, 6905401.43it/s]
# ^ finishes in under 1sec
```

I plan to write up a corresponding issue on `more_itertools`. Perhaps this isn't something fixable, but it's probably at least worthy of a warning in their documentation.