### PR TITLE
combsum dropping documents not appearing on both sides of +

### DIFF
--- a/pyterrier/transformer.py
+++ b/pyterrier/transformer.py
@@ -472,8 +472,8 @@ class CombSumTransformer(BinaryTransformerBase):
         both_cols = set(res1.columns) & set(res2.columns)
         both_cols.remove("qid")
         both_cols.remove("docno")
-        merged = res1.merge(res2, on=["qid", "docno"], suffixes=[None, "_r"])
-        merged["score"] = merged["score"] + merged["score_r"]
+        merged = res1.merge(res2, on=["qid", "docno"], suffixes=[None, "_r"], how='outer')
+        merged["score"] = merged["score"].fillna(0) + merged["score_r"].fillna(0)
         merged = merged.drop(columns=["%s_r" % col for col in both_cols])
         merged = add_ranks(merged)
         return merged

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -141,6 +141,22 @@ class TestOperators(BaseTestCase):
         self.assertEqual("doc1", rtr.iloc[0]["docno"])
         self.assertEqual(15, rtr.iloc[0]["score"])
 
+    def test_plus_notoverlap(self):
+        import pyterrier.transformer as ptt
+        mock1 = ptt.UniformTransformer(pd.DataFrame([["q1", "doc1", 5]], columns=["qid", "docno", "score"]))
+        mock2 = ptt.UniformTransformer(pd.DataFrame([["q1", "doc2", 10]], columns=["qid", "docno", "score"]))
+
+        combined = mock1 + mock2
+        # we dont need an input, as both Identity transformers will return anyway
+        rtr = combined.transform(None)
+
+        self.assertEqual(2, len(rtr))
+        self.assertEqual("q1", rtr.iloc[0]["qid"])
+        self.assertEqual("doc1", rtr.iloc[0]["docno"])
+        self.assertEqual(5, rtr.iloc[0]["score"])
+        self.assertEqual("doc2", rtr.iloc[1]["docno"])
+        self.assertEqual(10, rtr.iloc[1]["score"])
+
     def test_plus_more_cols(self):
         import pyterrier.transformer as ptt
         from pyterrier.model import add_ranks


### PR DESCRIPTION
The documentation of CombSumTransformer says that "Documents not present in one transformer are given a score of 0.". However, the implementation drops documents that do not appear in both input transformers. 

There is an argument for + to only be defined on exactly the same input documents, but if we define it exactly as the documentation states, it is more useful.