### PR TITLE
pyterrier loaded message to stderr

### DIFF
--- a/pyterrier/__init__.py
+++ b/pyterrier/__init__.py
@@ -133,7 +133,7 @@ def init(version=None, mem=None, packages=[], jvm_opts=[], redirect_io=True, log
     if "BUILD_DATE" in dir(tr_version):
         version_string += " (built by %s on %s)" % (tr_version.BUILD_USER, tr_version.BUILD_DATE)
     import sys
-    print("PyTerrier %s has loaded Terrier %s\n" % (__version__, version_string), file=file=sys.stderr)
+    print("PyTerrier %s has loaded Terrier %s\n" % (__version__, version_string), file=sys.stderr)
     properties = autoclass('java.util.Properties')()
     ApplicationSetup = autoclass('org.terrier.utility.ApplicationSetup')
 

--- a/pyterrier/__init__.py
+++ b/pyterrier/__init__.py
@@ -132,7 +132,8 @@ def init(version=None, mem=None, packages=[], jvm_opts=[], redirect_io=True, log
     version_string = tr_version.VERSION
     if "BUILD_DATE" in dir(tr_version):
         version_string += " (built by %s on %s)" % (tr_version.BUILD_USER, tr_version.BUILD_DATE)
-    print("PyTerrier %s has loaded Terrier %s" % (__version__, version_string))
+    import sys
+    print("PyTerrier %s has loaded Terrier %s\n" % (__version__, version_string), file=file=sys.stderr)
     properties = autoclass('java.util.Properties')()
     ApplicationSetup = autoclass('org.terrier.utility.ApplicationSetup')
 


### PR DESCRIPTION
When using pyterrier in a script and redirecting stdout (e.g., to a file), it's inconvenient to have the "PyTerrier has loaded Terrier" message appear at the top.