### PR TITLE
provide re-ranking runs from datasets

### DIFF
--- a/pyterrier/datasets.py
+++ b/pyterrier/datasets.py
@@ -107,6 +107,12 @@ class Dataset():
         """
         return None
 
+    def get_reranking_run(self, variant=None) -> pd.DataFrame:
+        """ 
+            Returns a standard run provided by the dataset used for re-ranking experiments.
+        """
+        pass
+
 class RemoteDataset(Dataset):
 
     def __init__(self, name, locations):
@@ -479,6 +485,20 @@ class IRDSDataset(Dataset):
 
         return df
 
+    def get_reranking_run(self, variant=None) -> pd.DataFrame:
+        """ 
+            Returns a standard run provided by the dataset used for re-ranking experiments.
+        """
+        ds = self.irds_ref()
+        assert ds.has_scoreddocs(), f"{self._irds_id} doesn't support get_reranking_run"
+        result = pd.DataFrame(ds.scoreddocs)
+        result = result.rename(columns={'query_id': 'qid', 'doc_id': 'docno'}) # convert irds field names to pyterrier names
+        result.sort_values(by=['qid', 'score', 'docno'], ascending=[True, False, True], inplace=True) # ensure data is sorted by qid, -score, did
+        # result doesn't yet contain queries (only qids) so load and merge them in
+        topics = self.get_topics(variant)
+        result = pd.merge(result, topics, how='left', on='qid', copy=False)
+        return result
+
     def _describe_component(self, component):
         ds = self.irds_ref()
         if component == "topics":
@@ -497,6 +517,8 @@ class IRDSDataset(Dataset):
             return None
         if component == "corpus":
             return ds.has_docs() or None
+        if component == "reranking_run":
+            return ds.has_scoreddocs() or None
         return None
 
     def info_url(self):

--- a/pyterrier/datasets.py
+++ b/pyterrier/datasets.py
@@ -107,9 +107,9 @@ class Dataset():
         """
         return None
 
-    def get_reranking_run(self, variant=None) -> pd.DataFrame:
+    def get_results(self, variant=None) -> pd.DataFrame:
         """ 
-            Returns a standard run provided by the dataset used for re-ranking experiments.
+            Returns a standard result set provided by the dataset. This is useful for re-ranking experiments.
         """
         pass
 
@@ -485,9 +485,9 @@ class IRDSDataset(Dataset):
 
         return df
 
-    def get_reranking_run(self, variant=None) -> pd.DataFrame:
+    def get_results(self, variant=None) -> pd.DataFrame:
         """ 
-            Returns a standard run provided by the dataset used for re-ranking experiments.
+            Returns a standard result set provided by the dataset. This is useful for re-ranking experiments.
         """
         ds = self.irds_ref()
         assert ds.has_scoreddocs(), f"{self._irds_id} doesn't support get_reranking_run"
@@ -517,7 +517,7 @@ class IRDSDataset(Dataset):
             return None
         if component == "corpus":
             return ds.has_docs() or None
-        if component == "reranking_run":
+        if component == "results":
             return ds.has_scoreddocs() or None
         return None
 

--- a/tests/test_irds_integration.py
+++ b/tests/test_irds_integration.py
@@ -57,19 +57,19 @@ class TestIrDatasetsIntegration(BaseTestCase):
                     index = pt.IndexFactory.of(indexref)
                     self.assertEqual(index.lexicon['covid'].frequency, 200582)
 
-    def test_reranking_run(self):
-        if "PYTERRIER_TEST_IRDS_RERANKING_RUN" in os.environ:
+    def test_results(self):
+        if "PYTERRIER_TEST_IRDS_RESULTS" in os.environ:
             dataset = pt.datasets.get_dataset('irds:msmarco-passage/trec-dl-2019/judged')
-            with self.subTest('reranking_run'):
-                reranking_run = dataset.get_reranking_run()
-                self.assertEqual(41042, len(reranking_run))
-                self.assertEqual(['qid', 'docno', 'score', 'query'], list(reranking_run.columns))
-                self.assertEqual('1037798', reranking_run.iloc[0].qid)
-                self.assertEqual('1031599', reranking_run.iloc[0].docno)
-                self.assertEqual(0., reranking_run.iloc[0].score)
-                self.assertEqual('who is robert gray', reranking_run.iloc[0].query)
+            with self.subTest('results'):
+                results = dataset.get_results()
+                self.assertEqual(41042, len(results))
+                self.assertEqual(['qid', 'docno', 'score', 'query'], list(results.columns))
+                self.assertEqual('1037798', results.iloc[0].qid)
+                self.assertEqual('1031599', results.iloc[0].docno)
+                self.assertEqual(0., results.iloc[0].score)
+                self.assertEqual('who is robert gray', results.iloc[0].query)
                 # ensure it's terrier-tokenised (orig text is "tracheids are part of _____.")
-                self.assertEqual('tracheids are part of', reranking_run[reranking_run.qid=='1124210'].iloc[0].query)
+                self.assertEqual('tracheids are part of', results[results.qid=='1124210'].iloc[0].query)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_irds_integration.py
+++ b/tests/test_irds_integration.py
@@ -57,5 +57,19 @@ class TestIrDatasetsIntegration(BaseTestCase):
                     index = pt.IndexFactory.of(indexref)
                     self.assertEqual(index.lexicon['covid'].frequency, 200582)
 
+    def test_reranking_run(self):
+        if "PYTERRIER_TEST_IRDS_RERANKING_RUN" in os.environ:
+            dataset = pt.datasets.get_dataset('irds:msmarco-passage/trec-dl-2019/judged')
+            with self.subTest('reranking_run'):
+                reranking_run = dataset.get_reranking_run()
+                self.assertEqual(41042, len(reranking_run))
+                self.assertEqual(['qid', 'docno', 'score', 'query'], list(reranking_run.columns))
+                self.assertEqual('1037798', reranking_run.iloc[0].qid)
+                self.assertEqual('1031599', reranking_run.iloc[0].docno)
+                self.assertEqual(0., reranking_run.iloc[0].score)
+                self.assertEqual('who is robert gray', reranking_run.iloc[0].query)
+                # ensure it's terrier-tokenised (orig text is "tracheids are part of _____.")
+                self.assertEqual('tracheids are part of', reranking_run[reranking_run.qid=='1124210'].iloc[0].query)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It's becoming increasingly common for datasets to include a standard initial result set for re-ranking experiments. ir_datasets provides these, but they are a bit inconvenient to use in pyterrier right now because it involves using `irds_ref`, building an appropriate dataframe, and merging in the query/document text.

This PR exposes the functionality more conveniently through `dataset.get_reranking_run()`. (I'm open to alternative names here.)

I also considered including the document text, but it's not always going to be needed and it seems more suitable to use the existing `pt.text.get_text()` pipeline for this.