### PR TITLE
read_results merge topics

### DIFF
--- a/pyterrier/io.py
+++ b/pyterrier/io.py
@@ -148,6 +148,27 @@ def read_results(filename, format="trec", topics=None, dataset=None, **kwargs):
 
     Returns:
         dataframe with usual qid, docno, score columns etc
+
+    Examples::
+
+        # a dataframe of results can be used directly in a pt.Experiment
+        pt.Experiment(
+            [ pt.io.read_results("/path/to/baselines-results.res.gz") ],
+            topics,
+            qrels,
+            ["map"]
+        )
+
+        # make a transformer from a results dataframe, include the query text
+        first_pass = pt.Transformer.from_df( pt.io.read_results("/path/to/results.gz", topics=topics) )
+        # make a max_passage retriever based on a previously saved results
+        max_passage = (first_pass 
+            >> pt.text.get_text(dataset)
+            >> pt.text.sliding()
+            >> pt.text.scorer()
+            >> pt.text.max_passage()
+        )
+
     """
     if not format in SUPPORTED_RESULTS_FORMATS:
         raise ValueError("Format %s not known, supported types are %s" % (format, str(SUPPORTED_RESULTS_FORMATS.keys())))

--- a/pyterrier/io.py
+++ b/pyterrier/io.py
@@ -135,13 +135,15 @@ def touch(fname, mode=0o666, dir_fd=None, **kwargs):
             dir_fd=None if os.supports_fd else dir_fd, **kwargs)
 
 
-def read_results(filename, format="trec", **kwargs):
+def read_results(filename, format="trec", topics=None, dataset=None, **kwargs):
     """
     Reads a file into a results dataframe.
 
     Parameters:
         filename (str): The filename of the file to be read. Compressed files are handled automatically. A URL is also supported for the "trec" format.
         format (str): The format of the results file: one of "trec", "letor". Default is "trec".
+        topics (None or pandas.DataFrame): If provided, will merge the topics to merge into the results. This is helpful for providing query text. Cannot be used in conjunction with dataset argument.
+        dataset (None, str or pyterrier.datasets.Dataset): If provided, loads topics from the dataset (or dataset ID) and merges them into the results. This is helpful for providing query text. Cannot be used in conjunction with dataset topics.
         **kwargs (dict): Other arguments for the internal method
 
     Returns:
@@ -149,7 +151,16 @@ def read_results(filename, format="trec", **kwargs):
     """
     if not format in SUPPORTED_RESULTS_FORMATS:
         raise ValueError("Format %s not known, supported types are %s" % (format, str(SUPPORTED_RESULTS_FORMATS.keys())))
-    return SUPPORTED_RESULTS_FORMATS[format][0](filename, **kwargs)
+    results = SUPPORTED_RESULTS_FORMATS[format][0](filename, **kwargs)
+    if dataset is not None:
+        assert topics is None, "Cannot provide both dataset and topics"
+        if isinstance(dataset, str):
+            import pyterrier as pt
+            dataset = pt.get_dataset(dataset)
+        topics = dataset.get_topics()
+    if topics is not None:
+        results = pd.merge(results, topics, how='left', on='qid')
+    return results
 
 def _read_results_letor(filename, labels=False):
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -155,8 +155,24 @@ class TestUtils(TempDirTestCase):
         with pt.io.autoopen('file.gz', 'rt') as f:
             self.assertEqual(f.read(), 'Shady\'s back')
 
+    def test_read_results_topic_merging(self):
+        orig_results = pd.DataFrame({
+            'qid': ['1', '1', '2'],
+            'docno': ['A', 'B', 'C'],
+            'score': [0.8, 0.4, 0.6],
+            'rank': [1, 2, 1]
+        })
+        pt.io.write_results(orig_results, 'test.res')
+        for results in [
+            pt.io.read_results('test.res', dataset='vaswani'),
+            pt.io.read_results('test.res', dataset=pt.get_dataset('vaswani')),
+            pt.io.read_results('test.res', topics=pt.get_dataset('vaswani').get_topics()),]:
+            self.assertEqual(results.iloc[0].query, 'measurement of dielectric constant of liquids by the use of microwave techniques')
+            self.assertEqual(results.iloc[1].query, 'measurement of dielectric constant of liquids by the use of microwave techniques')
+            self.assertEqual(results.iloc[2].query, 'mathematical analysis and design details of waveguide fed microwave radiations')
+
     def tearDown(self):
-        for file in ['file.txt', 'file.tmp.txt', 'file.gz', 'file.tmp.gz']:
+        for file in ['file.txt', 'file.tmp.txt', 'file.gz', 'file.tmp.gz', 'test.res']:
             if os.path.exists(file):
                 os.remove(file)
 


### PR DESCRIPTION
When reading results files for further processing (e.g., using a saved result file for further re-ranking), you usually will need an additional column that's not saved in the file: `query`. This can be accomplished by the user by loading the dataset's topics and performing a `pd.merge()` on the results and topics dataframes, but this is inconvinenet.

This PR provides several options to help the user load a results dataframe that includes topics with more ease. They can either:
 - Pass a `dataset` into `read_results`, either as a string identifier or as a Dataset object. The topics for this dataset will be loaded and merged with the results.
 - Pass `topics` into `read_results`. These topics will be merged with the results. This is handy if the user already has the topics handy, or if they do not come directly from a dataset.

Functionality would be ambiguous if both options were given, so these two options are exclusive. An assertion error will be thrown if both are provided by the user.