### PR TITLE
fixed bug with is_transformer

### DIFF
--- a/pyterrier/transformer.py
+++ b/pyterrier/transformer.py
@@ -16,7 +16,7 @@ def is_function(v):
     return isinstance(v, types.FunctionType)
 
 def is_transformer(v):
-    if isinstance(v, TransformerBase):
+    if isinstance(v, Transformer):
         return True
     return False
 

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,0 +1,19 @@
+import pyterrier as pt
+import unittest
+from .base import BaseTestCase
+import os
+import pandas as pd
+
+class TestTransformer(BaseTestCase):
+
+    def test_is_transformer(self):
+        class MyTransformer1(pt.Transformer):
+            pass
+        class MyTransformer2(pt.transformer.TransformerBase):
+            pass
+        class MyTransformer3(pt.transformer.IterDictIndexerBase):
+            pass
+        class MyTransformer4(pt.transformer.EstimatorBase):
+            pass
+        for T in [MyTransformer1, MyTransformer2, MyTransformer3, MyTransformer4]:
+            self.assertTrue(pt.transformer.is_transformer(T()))


### PR DESCRIPTION
Related to #258 -- subclasses of `pt.Transformer` doesn't pass `is_transformer` check because it checks for `TransformerBase` (a subclass of `Transformer`).

This means that you wouldn't be able to use a subclass of `pt.Transformer` in a pipeline. E.g.,

```python
class MyModel(pt.Transformer):
    pass
bm25 >> MyModel() # would fail with message saying MyModel cannot be coerced into a transformer
```

Since most code still uses `TransformerBase`, it doesn't break existing code -- just new stuff written using the new name.

Added tests that failed with previous impl and added fix.