### PR TITLE
defer loading ir_datasets

### DIFF
--- a/pyterrier/datasets.py
+++ b/pyterrier/datasets.py
@@ -381,11 +381,13 @@ class RemoteDataset(Dataset):
 
 
 class IRDSDataset(Dataset):
-    def __init__(self, irds_id):
+    def __init__(self, irds_id, defer_load=False):
         self._irds_id = irds_id
-        self._irds_ref = ir_datasets.load(self._irds_id)
+        self._irds_ref = None if defer_load else ir_datasets.load(self._irds_id)
 
     def irds_ref(self):
+        if self._irds_ref is None:
+            self._irds_ref = ir_datasets.load(self._irds_id)
         return self._irds_ref
 
     def get_corpus(self):
@@ -1056,7 +1058,7 @@ DATASET_MAP = {
 # ...
 import ir_datasets
 for ds_id in ir_datasets.registry:
-    DATASET_MAP[f'irds:{ds_id}'] = IRDSDataset(ds_id)
+    DATASET_MAP[f'irds:{ds_id}'] = IRDSDataset(ds_id, defer_load=True)
 
 # "trec-deep-learning-docs"
 #DATASET_MAP['msmarco_document'] = DATASET_MAP["trec-deep-learning-docs"]


### PR DESCRIPTION
Context: calling `ir_datasets.load` can give a warning message that indicates if a dataset is deprecated. Without this change, the warning would come up every time, regardless of whether the dataset was actually used. With the change, the warning will only appear if the user specifically requests the dataset and does something with it (only the first time).

This change does not degrade the behaviour of on-demand generated datasets (such as those from CLIRMatrix), as the load is not deferred in that cause.