### PR TITLE
Set meta and meta_lengths in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,10 @@ By downloading and using PyTerrier, you agree to cite at the undernoted paper de
  - Alex Tsolov, University of Glasgow
  - Craig Macdonald, University of Glasgow
  - Nicola Tonellotto, University of Pisa
- - Arthur Câmara, Delft University
+ - Arthur Câmara, TU Delft
  - Alberto Ueda, Federal University of Minas Gerais
  - Sean MacAvaney, Georgetown University/University of Glasgow
  - Chentao Xu, University of Glasgow
  - Sarawoot Kongyoung, University of Glasgow
  - Zhan Su, Copenhagen University
+ - Marcus Schutte, TU Delft

--- a/docs/terrier-indexing.rst
+++ b/docs/terrier-indexing.rst
@@ -89,8 +89,8 @@ IterDictIndexer
 An iterdict can just be a list of dictionaries::
 
     docs = [ { 'docno' : 'doc1', 'text' : 'a b c' }  ]
-    iter_indexer = pt.IterDictIndexer("./index")
-    indexref1 = iter_indexer.index(docs, meta=['docno', 'text'], meta_lengths=[20, 4096])
+    iter_indexer = pt.IterDictIndexer("./index", meta=['docno', 'text'], meta_lengths=[20, 4096])
+    indexref1 = iter_indexer.index(docs)
 
 A dataframe can also be used, virtue of its ``.to_dict()`` method::
 
@@ -108,8 +108,8 @@ For example, the tsv file of the MSMARCO Passage Ranking corpus can be indexed a
                 docno, passage = l.split("\t")
                 yield {'docno' : docno, 'text' : passage}
     
-    iter_indexer = pt.IterDictIndexer("./passage_index")
-    indexref3 = iter_indexer.index(msmarco_generate(), meta=['docno', 'text'], meta_lengths=[20, 4096])
+    iter_indexer = pt.IterDictIndexer("./passage_index", meta=['docno', 'text'], meta_lengths=[20, 4096])
+    indexref3 = iter_indexer.index(msmarco_generate())
 
 IterDictIndexer can be used in connection with :ref:`indexing_pipelines`.
 
@@ -123,7 +123,7 @@ Similarly, indexing of JSONL files is similarly a few lines of Python::
           # yields a dictionary for each json line 
           yield json.loads(l)
 
-    indexref4 = pt.IterDictIndexer("./index").index(iter_file("/path/to/file.jsonl"), meta=['docno', 'text'], meta_lengths=[20, 4096])
+    indexref4 = pt.IterDictIndexer("./index", meta=['docno', 'text'], meta_lengths=[20, 4096]).index(iter_file("/path/to/file.jsonl"))
   
 NB: Use ``pt.io.autoopen()`` as a drop-in replacement for ``open()`` that supports files compressed by gzip etc.
 
@@ -145,8 +145,8 @@ Example using Indexing Pipelines::
 
 On UNIX-based systems, IterDictIndexer can also perform multi-threaded indexing::
 
-    iter_indexer = pt.IterDictIndexer("./passage_index_8", threads=8)
-    indexref6 = iter_indexer.index(msmarco_generate(), meta=['docno', 'text'], meta_lengths=[20, 4096])
+    iter_indexer = pt.IterDictIndexer("./passage_index_8", meta=['docno', 'text'], meta_lengths=[20, 4096], threads=8)
+    indexref6 = iter_indexer.index(msmarco_generate())
 
 Note that the resulting index ordering with multiple threads is non-deterministic; if you need 
 deterministic behavior you must index in single-threaded mode. Furthermore, indexing can only go


### PR DESCRIPTION
Meta and mata_lengths parameters in index are deprecated and should be set in constructor.