### PR TITLE
Update index.py

### DIFF
--- a/pyterrier/index.py
+++ b/pyterrier/index.py
@@ -41,6 +41,7 @@ IndexFactory = None
 StructureMerger = None
 BlockStructureMerger = None
 
+IterDictIndexerBase = Index # backwards compat
 
 # lastdoc ensures that a Document instance from a Collection is not GCd before Java has used it.
 lastdoc=None

--- a/pyterrier/index.py
+++ b/pyterrier/index.py
@@ -41,7 +41,11 @@ IndexFactory = None
 StructureMerger = None
 BlockStructureMerger = None
 
-IterDictIndexerBase = Index # backwards compat
+# for backward compatibility
+class IterDictIndexerBase(Indexer):
+    @deprecated(version="0.9", reason="Use pt.Indexer instead of IterDictIndexerBase")
+    def __init__(self, *args, **kwargs):
+        super(Indexer, self).__init__(*args, **kwargs)
 
 # lastdoc ensures that a Document instance from a Collection is not GCd before Java has used it.
 lastdoc=None

--- a/pyterrier/index.py
+++ b/pyterrier/index.py
@@ -15,6 +15,7 @@ import threading
 import select
 import math
 from warnings import warn
+from deprecated import deprecated
 from collections import deque
 from typing import List, Dict, Union, Any
 


### PR DESCRIPTION
Keep IterDictIndexerBase around for backwards compatibility

prevents errors like:

```
Traceback (most recent call last):                                                                                                                                                    
  File "example.py", line 5, in <module>                                                                                                                                              
    from odis import Prf, ElectraScorer, LexDistil, DirectIndex                                                                                                                       
  File "/home/sean/ws/odis/odis/__init__.py", line 3, in <module>                                                                                                                     
    from .lexdistil import LexDistil                                                                                                                                                  
  File "/home/sean/ws/odis/odis/lexdistil.py", line 8, in <module>                                                                                                                    
    from pyterrier_dr import DocnoFile                                                                                                                                                
  File "/home/sean/miniconda3/envs/py37/lib/python3.7/site-packages/pyterrier_dr/__init__.py", line 1, in <module>                                 
    from .indexes import DocnoFile, NilIndex, NumpyIndex, RankedLists, FaissFlat, FaissHnsw, MemIndex, TorchIndex                                      
  File "/home/sean/miniconda3/envs/py37/lib/python3.7/site-packages/pyterrier_dr/indexes.py", line 114, in <module>                                                 
    class NilIndex(pt.index.IterDictIndexerBase):                                                                                                                                     
AttributeError: module 'pyterrier.index' has no attribute 'IterDictIndexerBase'                                                                                                       
```