### PR TITLE
Nofifo pretok indexing fixes

### DIFF
--- a/pyterrier/index.py
+++ b/pyterrier/index.py
@@ -91,7 +91,6 @@ def run_autoclass():
     Collection = autoclass("org.terrier.indexing.Collection")
     Arrays = autoclass("java.util.Arrays")
     Array = autoclass('java.lang.reflect.Array')
-    HashMap = autoclass('java.util.HashMap')
     ApplicationSetup = autoclass('org.terrier.utility.ApplicationSetup')
     Properties = autoclass('java.util.Properties')
     CLITool = autoclass("org.terrier.applications.CLITool")

--- a/pyterrier/index.py
+++ b/pyterrier/index.py
@@ -1141,6 +1141,9 @@ class DocListIterator(PythonJavaClass):
     def __init__(self, pyiterator):
         self.pyiterator = pyiterator
         self.hasnext = True
+        self.lastdoc = None
+        import pyterrier as pt
+        self.tr57 = not pt.check_version("5.8")
 
     @staticmethod 
     def pyDictToMap(a_dict): #returns Map<String,String>
@@ -1149,11 +1152,18 @@ class DocListIterator(PythonJavaClass):
             rtr.put(k, v)
         return rtr
 
-    @staticmethod
-    def pyDictToMapEntry(doc_dict : Dict[str,Any]): #returns Map.Entry<Map<String,String>, DocumentPostingList>>
+    def pyDictToMapEntry(self,doc_dict : Dict[str,Any]): #returns Map.Entry<Map<String,String>, DocumentPostingList>>
         dpl = DocListIterator.dpl_class()
-        for t,tf in doc_dict["toks"].items():
-            dpl.insert(int(tf), t)
+        # this works around a bug in the counting of doc lengths in Tr 5.7
+        if self.tr57:
+            for t,tf in doc_dict["toks"].items():
+                for i in range(int(tf)):
+                    dpl.insert(t)
+        else: #this code for 5.8 onwards
+            for t,tf in doc_dict["toks"].items():
+                for i in range(int(tf)):
+                    dpl.insert(int(tf), t)
+        
         # we cant make the toks column into the metaindex as it isnt a string. remove it.
         del doc_dict["toks"]
         return DocListIterator.tuple_class(DocListIterator.pyDictToMap(doc_dict), dpl)
@@ -1164,15 +1174,15 @@ class DocListIterator(PythonJavaClass):
 
     @java_method('()Ljava/lang/Object;')
     def next(self):
-        #TODO how to do this
-        ##
         try:
             doc_dict = next(self.pyiterator)
         except StopIteration as se:
             self.hasnext = False
             # terrier will ignore a null return from an iterator
             return None
-        return DocListIterator.pyDictToMapEntry(doc_dict)
+        # keep this around to prevent being GCd before Java can read it
+        self.lastdoc = self.pyDictToMapEntry(doc_dict)
+        return self.lastdoc
         
 
 class TQDMCollection(PythonJavaClass):

--- a/tests/test_iterdictindex_pretok.py
+++ b/tests/test_iterdictindex_pretok.py
@@ -10,6 +10,50 @@ from unittest import SkipTest
 from .base import TempDirTestCase, BaseTestCase
 
 class TestIterDictIndexerPreTok(TempDirTestCase):
+
+    def test_dpl(self):
+        pt.index.run_autoclass()
+        it1 = [
+            {'docno': 'd1', 'url': 'url1', "toks" : {"a" : 1, "b" : 2}}
+        ]
+        it2 = [
+            {'docno': 'd1', 'url': 'url1', "toks" : {"a" : 1, "b" : 2}},
+            {'docno': 'd2', 'url': 'url1', "toks" : {"a" : 1, "b" : 1}}
+        ]
+        from pyterrier.index import DocListIterator
+        
+        iterator =  DocListIterator(iter(it1))
+        self.assertTrue(iterator.hasNext())
+        obj = iterator.next()
+        self.assertIsNotNone(obj)
+        self.assertEqual("d1", obj.getKey().get("docno"))
+        self.assertEqual(2, obj.getValue().getFrequency("b"))
+        self.assertEqual(3, obj.getValue().getDocumentLength())
+        
+        if iterator.hasNext():
+            obj = iterator.next()
+            self.assertIsNone(obj)
+        self.assertFalse(iterator.hasNext())
+
+        iterator =  DocListIterator(iter(it2))
+        self.assertTrue(iterator.hasNext())
+        obj = iterator.next()
+        self.assertIsNotNone(obj)
+        self.assertEqual("d1", obj.getKey().get("docno"))
+        self.assertEqual(2, obj.getValue().getFrequency("b"))
+
+        self.assertTrue(iterator.hasNext())
+        obj = iterator.next()
+        self.assertIsNotNone(obj)
+        self.assertEqual(1, obj.getValue().getFrequency("b"))
+        self.assertEqual("d2", obj.getKey().get("docno"))
+
+        if iterator.hasNext():
+            obj = iterator.next()
+            self.assertIsNone(obj)
+        self.assertFalse(iterator.hasNext())
+
+
     
     def test_json_pretok_iterator(self):
         if not pt.check_version("5.7") or not pt.check_version("0.0.7", helper=True):
@@ -45,7 +89,7 @@ class TestIterDictIndexerPreTok(TempDirTestCase):
         # Test both versions: _fifo (for UNIX) and _nofifo (for Windows)
         indexers = [
             pt.index._IterDictIndexer_fifo(self.test_dir, type=index_type, meta=meta, pretokenised=True),
-            #pt.index._IterDictIndexer_fifo(self.test_dir, type=index_type, threads=4, meta=meta, pretokenised=True),
+            pt.index._IterDictIndexer_fifo(self.test_dir, type=index_type, threads=4, meta=meta, pretokenised=True),
             pt.index._IterDictIndexer_nofifo(self.test_dir, type=index_type, meta=meta, pretokenised=True),
         ]
         if BaseTestCase.is_windows():


### PR DESCRIPTION
After Terrier 5.7 release and the helper release to Maven, it became clear that pretokenised wasnt working on Windows. This PR addresses this (its a race-like GC problem actually), and also works around a minor bug in Tr5.7