### PR TITLE
allow to put term and LexiconEntry into a tuple

### DIFF
--- a/docs/terrier-index-api.rst
+++ b/docs/terrier-index-api.rst
@@ -83,18 +83,20 @@ lookup can be done like accessing a dictionary::
 
     index.getLexicon()["chemic"].getDocumentFrequency()
 
-As our index is stemmed, we used the stemmed form of the word 'chemical' which is 'chemic'
+As our index is stemmed, we used the stemmed form of the word 'chemical' which is 'chemic'.
 
 How can I see all terms in an index?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We can iterate over a Lexicon. Like calling the ``iterator()`` method of 
-`LexiconEntry <http://terrier.org/docs/current/javadoc/org/terrier/structures/Lexicon.html>`_, 
-in Java, each iteration obtains a ``Map.Entry<String,LexiconEntry>``. If the statistics of each term 
-are required, these are available from the LexiconEntry, c.f. ``kv.getValue()``::
+`Lexicon <http://terrier.org/docs/current/javadoc/org/terrier/structures/Lexicon.html>`_, 
+in Java, each iteration obtains a ``Map.Entry<String,LexiconEntry>``. This can be decoded, 
+so we can iterate over each term and LexiconEntry (which provides access to the statistics 
+of each term) contained within the Lexicon.  
 
-    for kv in index.getLexicon():
-        print(kv.getKey())
+    for term, le in index.getLexicon():
+        print(term)
+        print(le.getFrequency())
 
 What is the un-smoothed probability of term Y occurring in the collection?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/notebooks/index_api.ipynb
+++ b/examples/notebooks/index_api.ipynb
@@ -1,24 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "Copy of Indexing Demo.ipynb",
-      "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "TNdMHD8LS2Bm",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "TNdMHD8LS2Bm"
       },
       "source": [
         "# PyTerrier Index Analysis examples\n",
@@ -29,8 +15,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "pkMrNonZrpEg",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "pkMrNonZrpEg"
       },
       "source": [
         "## Prerequisites\n",
@@ -40,22 +26,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 1,
       "metadata": {
-        "id": "JWLqWXBHeBRc",
-        "colab_type": "code",
-        "outputId": "618fe9cb-2bd3-47ff-fbdf-816d4b1cadce",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 765
+        },
+        "colab_type": "code",
+        "id": "JWLqWXBHeBRc",
+        "outputId": "618fe9cb-2bd3-47ff-fbdf-816d4b1cadce",
+        "vscode": {
+          "languageId": "python"
         }
       },
-      "source": [
-        "!pip install python-terrier\n",
-        "# !pip install --upgrade git+https://github.com/terrier-org/pyterrier.git#egg=python-terrier"
-      ],
-      "execution_count": 1,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "Collecting python-terrier\n",
@@ -102,16 +88,18 @@
             "Successfully built python-terrier wget pytrec-eval hopcroftkarp\n",
             "Installing collected packages: pyjnius, wget, pytrec-eval, multiset, hopcroftkarp, matchpy, deprecation, python-terrier\n",
             "Successfully installed deprecation-2.1.0 hopcroftkarp-1.2.5 matchpy-0.5.1 multiset-2.1.1 pyjnius-1.3.0 python-terrier-0.1.3 pytrec-eval-0.4 wget-3.2\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "%pip install -q python-terrier\n"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ixzDjvtTOQbB",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "ixzDjvtTOQbB"
       },
       "source": [
         "## Init \n",
@@ -129,39 +117,42 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 2,
       "metadata": {
-        "id": "k3ltUZ8PgWmz",
-        "colab_type": "code",
-        "outputId": "28681afb-8132-4cde-a0eb-6dc4c53da1b4",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 85
+        },
+        "colab_type": "code",
+        "id": "k3ltUZ8PgWmz",
+        "outputId": "28681afb-8132-4cde-a0eb-6dc4c53da1b4",
+        "vscode": {
+          "languageId": "python"
         }
       },
-      "source": [
-        "import pyterrier as pt\n",
-        "if not pt.started():\n",
-        "  pt.init()"
-      ],
-      "execution_count": 2,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "terrier-assemblies 5.2  jar-with-dependencies not found, downloading to /root/.pyterrier...\n",
             "Done\n",
             "terrier-python-helper 0.0.2  jar not found, downloading to /root/.pyterrier...\n",
             "Done\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "import pyterrier as pt\n",
+        "if not pt.started():\n",
+        "  pt.init()"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "By5UFYnRLgD0",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "By5UFYnRLgD0"
       },
       "source": [
         "## Loading an Index\n",
@@ -171,36 +162,39 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 3,
       "metadata": {
-        "id": "eRx5kIL9nmsB",
-        "colab_type": "code",
-        "outputId": "b6774593-d847-4d23-bd77-c266b8a32d2f",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 34
+        },
+        "colab_type": "code",
+        "id": "eRx5kIL9nmsB",
+        "outputId": "b6774593-d847-4d23-bd77-c266b8a32d2f",
+        "vscode": {
+          "languageId": "python"
         }
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Downloading vaswani index to /root/.pyterrier/corpora/vaswani/index\n"
+          ]
+        }
+      ],
       "source": [
         "dataset = pt.datasets.get_dataset(\"vaswani\")\n",
         "\n",
         "indexref = dataset.get_index()"
-      ],
-      "execution_count": 3,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Downloading vaswani index to /root/.pyterrier/corpora/vaswani/index\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "orZfC5vY-NQT",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "orZfC5vY-NQT"
       },
       "source": [
         "Lets have a look at the statistics of this index."
@@ -208,23 +202,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 4,
       "metadata": {
-        "id": "YxW1gSJh-MLr",
-        "colab_type": "code",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 119
         },
-        "outputId": "d0ef80f7-de1a-4e1f-ddb3-dd8d98d634e7"
+        "colab_type": "code",
+        "id": "YxW1gSJh-MLr",
+        "outputId": "d0ef80f7-de1a-4e1f-ddb3-dd8d98d634e7",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "index = pt.IndexFactory.of(indexref)\n",
-        "\n",
-        "print(index.getCollectionStatistics().toString())"
-      ],
-      "execution_count": 4,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "Number of documents: 11429\n",
@@ -233,16 +226,20 @@
             "Field names: []\n",
             "Number of tokens: 271581\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "index = pt.IndexFactory.of(indexref)\n",
+        "\n",
+        "print(index.getCollectionStatistics().toString())"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "KLlaucxq-i4b",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "KLlaucxq-i4b"
       },
       "source": [
         "## Using a Terrier index in your own code"
@@ -251,8 +248,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "W7zH4-Y2-n7a",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "W7zH4-Y2-n7a"
       },
       "source": [
         "### How many documents does term X occur in?\n",
@@ -262,39 +259,42 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 9,
       "metadata": {
-        "id": "r1en_8ga-Y0d",
-        "colab_type": "code",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 34
         },
-        "outputId": "8feff0b9-53ab-4acd-be51-150359b9c3ff"
+        "colab_type": "code",
+        "id": "r1en_8ga-Y0d",
+        "outputId": "8feff0b9-53ab-4acd-be51-150359b9c3ff",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "index.getLexicon()[\"chemic\"].getDocumentFrequency()"
-      ],
-      "execution_count": 9,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "20"
             ]
           },
+          "execution_count": 9,
           "metadata": {
             "tags": []
           },
-          "execution_count": 9
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "index.getLexicon()[\"chemic\"].getDocumentFrequency()"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "_61z-MQQ-48S",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "_61z-MQQ-48S"
       },
       "source": [
         "### What is the un-smoothed probability of term Y occurring in the collection?\n",
@@ -306,39 +306,42 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 10,
       "metadata": {
-        "id": "7jEPzyru-tCF",
-        "colab_type": "code",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 34
         },
-        "outputId": "b0f0b461-be41-4382-cfa2-22de5cac3f1c"
+        "colab_type": "code",
+        "id": "7jEPzyru-tCF",
+        "outputId": "b0f0b461-be41-4382-cfa2-22de5cac3f1c",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "index.getLexicon()[\"chemic\"].getFrequency() / index.getCollectionStatistics().getNumberOfTokens() if \"chemic\" in index.getLexicon() else 0"
-      ],
-      "execution_count": 10,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "7.732499696223226e-05"
             ]
           },
+          "execution_count": 10,
           "metadata": {
             "tags": []
           },
-          "execution_count": 10
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "index.getLexicon()[\"chemic\"].getFrequency() / index.getCollectionStatistics().getNumberOfTokens() if \"chemic\" in index.getLexicon() else 0"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "4O5oTE5m_72-",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "4O5oTE5m_72-"
       },
       "source": [
         "### What terms occur in the 11th document?\n"
@@ -346,29 +349,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 15,
       "metadata": {
-        "id": "DS2aAdbE_OqA",
-        "colab_type": "code",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 357
         },
-        "outputId": "1c0abbad-0664-423a-8c51-b41d0f22124b"
+        "colab_type": "code",
+        "id": "DS2aAdbE_OqA",
+        "outputId": "1c0abbad-0664-423a-8c51-b41d0f22124b",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "di = index.getDirectIndex()\n",
-        "doi = index.getDocumentIndex()\n",
-        "lex = index.getLexicon()\n",
-        "docid = 10 #docids are 0-based\n",
-        "#NB: postings will be null if the document is empty\n",
-        "for posting in  di.getPostings(doi.getDocumentEntry(docid)):\n",
-        "  termid = posting.getId()\n",
-        "  lee = lex.getLexiconEntry(termid)\n",
-        "  print(\"%s with frequency %d\" % (lee.getKey(),posting.getFrequency()))"
-      ],
-      "execution_count": 15,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "circuit with frequency 3\n",
@@ -391,16 +387,26 @@
             "diagram with frequency 1\n",
             "line with frequency 1\n",
             "static with frequency 1\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "di = index.getDirectIndex()\n",
+        "doi = index.getDocumentIndex()\n",
+        "lex = index.getLexicon()\n",
+        "docid = 10 #docids are 0-based\n",
+        "#NB: postings will be null if the document is empty\n",
+        "for posting in  di.getPostings(doi.getDocumentEntry(docid)):\n",
+        "  termid = posting.getId()\n",
+        "  lee = lex.getLexiconEntry(termid)\n",
+        "  print(\"%s with frequency %d\" % (lee.getKey(),posting.getFrequency()))"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "pOMptWqtAmUP",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "pOMptWqtAmUP"
       },
       "source": [
         "### What documents does term \"Z\" occur in?"
@@ -408,28 +414,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 18,
       "metadata": {
-        "id": "CfDga790AZ26",
-        "colab_type": "code",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 357
         },
-        "outputId": "ab52b562-cc5b-4733-a9fc-934ca7fc71f5"
+        "colab_type": "code",
+        "id": "CfDga790AZ26",
+        "outputId": "ab52b562-cc5b-4733-a9fc-934ca7fc71f5",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "meta = index.getMetaIndex()\n",
-        "inv = index.getInvertedIndex()\n",
-        "\n",
-        "le = lex.getLexiconEntry( \"chemic\" )\n",
-        "# the lexicon entry is also our pointer to access the inverted index posting list\n",
-        "for posting in inv.getPostings( le ): \n",
-        "\tdocno = meta.getItem(\"docno\", posting.getId())\n",
-        "\tprint(\"%s with frequency %d \" % (docno, posting.getFrequency()))"
-      ],
-      "execution_count": 18,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "1056 with frequency 1 \n",
@@ -452,16 +452,25 @@
             "10139 with frequency 1 \n",
             "10445 with frequency 1 \n",
             "10703 with frequency 1 \n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "meta = index.getMetaIndex()\n",
+        "inv = index.getInvertedIndex()\n",
+        "\n",
+        "le = lex.getLexiconEntry( \"chemic\" )\n",
+        "# the lexicon entry is also our pointer to access the inverted index posting list\n",
+        "for posting in inv.getPostings( le ): \n",
+        "\tdocno = meta.getItem(\"docno\", posting.getId())\n",
+        "\tprint(\"%s with frequency %d \" % (docno, posting.getFrequency()))"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "pWdJTL58BLge",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "pWdJTL58BLge"
       },
       "source": [
         "Our index does not have position information, but *if it did*, the above loop would look like:\n",
@@ -478,8 +487,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "yb1tfXz0B5EY",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "yb1tfXz0B5EY"
       },
       "source": [
         "### What are the PL2 weighting model scores of documents that \"Y\" occurs in?\n",
@@ -489,33 +498,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 20,
       "metadata": {
-        "id": "JVO3BjLTBBXb",
-        "colab_type": "code",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 357
         },
-        "outputId": "c5d8e8d9-266a-4480-bc28-e08164af2bcc"
+        "colab_type": "code",
+        "id": "JVO3BjLTBBXb",
+        "outputId": "c5d8e8d9-266a-4480-bc28-e08164af2bcc",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [
-        "inv = index.getInvertedIndex()\n",
-        "meta = index.getMetaIndex()\n",
-        "lex = index.getLexicon()\n",
-        "le = lex.getLexiconEntry( \"chemic\" )\n",
-        "wmodel = pt.autoclass(\"org.terrier.matching.models.PL2\")()\n",
-        "wmodel.setCollectionStatistics(index.getCollectionStatistics())\n",
-        "wmodel.setEntryStatistics(le);\n",
-        "wmodel.setKeyFrequency(1)\n",
-        "wmodel.prepare()\n",
-        "for posting in inv.getPostings(le):\n",
-        "  docno = meta.getItem(\"docno\", posting.getId())\n",
-        "  score = wmodel.score(posting)\n",
-        "  print(\"%s with score %0.4f\"  % (docno, score))\n"
-      ],
-      "execution_count": 20,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "1056 with score 6.3584\n",
@@ -538,21 +536,52 @@
             "10139 with score 5.2230\n",
             "10445 with score 3.6754\n",
             "10703 with score 6.9992\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "inv = index.getInvertedIndex()\n",
+        "meta = index.getMetaIndex()\n",
+        "lex = index.getLexicon()\n",
+        "le = lex.getLexiconEntry( \"chemic\" )\n",
+        "wmodel = pt.autoclass(\"org.terrier.matching.models.PL2\")()\n",
+        "wmodel.setCollectionStatistics(index.getCollectionStatistics())\n",
+        "wmodel.setEntryStatistics(le);\n",
+        "wmodel.setKeyFrequency(1)\n",
+        "wmodel.prepare()\n",
+        "for posting in inv.getPostings(le):\n",
+        "  docno = meta.getItem(\"docno\", posting.getId())\n",
+        "  score = wmodel.score(posting)\n",
+        "  print(\"%s with score %0.4f\"  % (docno, score))\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "j7HZ9-cPCkEU",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "j7HZ9-cPCkEU",
+        "vscode": {
+          "languageId": "python"
+        }
       },
-      "source": [],
-      "execution_count": 0,
-      "outputs": []
+      "outputs": [],
+      "source": []
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "Copy of Indexing Demo.ipynb",
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/pyterrier/bootstrap.py
+++ b/pyterrier/bootstrap.py
@@ -51,6 +51,20 @@ def setup_jnius():
         if 2147483647 == nextid:
             raise StopIteration()
         return self
+    
+    # Map$Entry can be decoded like a tuple
+    def MEgetitem(self, i):
+        if i == 0:
+            return self.getKey()
+        if i == 1:
+            return self.getValue()
+        raise IndexError()
+    
+    protocol_map['java.util.Map$Entry'] = {
+        '__getitem__' : MEgetitem,
+        '__iter__' : lambda self: iter([self.getKey(), self.getValue()]),
+        '__len__' : lambda self: 2
+    }
 
     protocol_map["org.terrier.structures.postings.IterablePosting"] = {
         '__iter__': lambda self: self,

--- a/tests/test_dunder.py
+++ b/tests/test_dunder.py
@@ -88,8 +88,7 @@ class TestDunder(TempDirTestCase):
                  'The body may perhaps compensates for the loss']
         })
         import pyterrier as pt
-        pd_indexer = pt.DFIndexer(self.test_dir)
-        pd_indexer.properties["termpipelines"] = ""
+        pd_indexer = pt.DFIndexer(self.test_dir, stopwords=pt.TerrierStopwords.none, stemmer=pt.TerrierStemmer.none)
         indexref = pd_indexer.index(df["text"], df["docno"])
         index = pt.IndexFactory.of(indexref)
         self.assertIsNotNone(index)
@@ -109,6 +108,14 @@ class TestDunder(TempDirTestCase):
         self.assertTrue("crashing" in index.getLexicon())
         self.assertEqual(1, index.getLexicon()["crashing"].getFrequency())
         self.assertFalse("dentish" in index.getLexicon())
+        
+        # test Map$Entry can be decoded like a tuple
+        # both within an iterator, and separately
+        x, y = index.getLexicon().getLexiconEntry(0)
+        term_count = 0
+        for term, entry in index.getLexicon():
+            term_count += 1
+        self.assertEqual(term_count, index.getLexicon().numberOfEntries())
 
         # now test that IterablePosting has had its dunder methods added
         postings = index.getInvertedIndex().getPostings(index.getLexicon()["crashing"])

--- a/tests/test_dunder.py
+++ b/tests/test_dunder.py
@@ -116,6 +116,12 @@ class TestDunder(TempDirTestCase):
         for term, entry in index.getLexicon():
             term_count += 1
         self.assertEqual(term_count, index.getLexicon().numberOfEntries())
+        term_count = 0
+        for lee in index.getLexicon():
+            term_count += 1
+            lee.getKey()
+            lee.getValue()
+        self.assertEqual(term_count, index.getLexicon().numberOfEntries())
 
         # now test that IterablePosting has had its dunder methods added
         postings = index.getInvertedIndex().getPostings(index.getLexicon()["crashing"])


### PR DESCRIPTION
This PR comes from a suggestion by @catenamatteo 

Currently, to iterate over the lexicon, we have to do this:
```python
for kv in lexicon:
  term = kv.getKey()
  lexiconentry = kv.getValue()
  print(term, lexiconentry)
```

Instead, this PR allows a simplification to make the API more Pythonic:
```python
for term, lexiconentry in lexicon:
  print(term, lexiconentry)
```