### PR TITLE
added tokenizer as arg for pt.text.sliding

### DIFF
--- a/pyterrier/text.py
+++ b/pyterrier/text.py
@@ -165,10 +165,12 @@ def sliding( text_attr='body', length=150, stride=75, join=' ', prepend_attr='ti
     applying this transformer, docnos are altered by adding '%p' and a passage number. The original scores for each document can be recovered
     by aggregation functions, such as `max_passage()`.
 
-    For the puposes of obtaining passages of a given length, tokenisation is perfomed by using the `tokenizer` object passed as an argument. 
-    The `tokenizer` object must have a `.tokenize(str) -> list[str]` method. By default, tokenisation is perfomed by splitting on one-or-more spaces, 
-    i.e. based on the Python regular expression ``re.compile(r'\s+')``.
-
+    For the puposes of obtaining passages of a given length, the tokenisation can be controlled. By default, tokenisation takes place by splitting
+    on space, i.e. based on the Python regular expression ``re.compile(r'\s+')``. However, more fine-grained tokenisation can applied by passing 
+    an object matching the HuggingFace Transformers `Tokenizer API <https://huggingface.co/docs/transformers/main/en/main_classes/tokenizer#transformers.PreTrainedTokenizer>`_ 
+    as the `tokenizer` kwarg argument. In short, the `tokenizer` object must have a `.tokenize(str) -> list[str]` method and 
+    `.convert_tokens_to_string(list[str]) -> str` for detokenisation.
+    
     Parameters:
         text_attr(str): what is the name of the dataframe attribute containing the main text of the document to be split into passages.
             Default is 'body'.

--- a/pyterrier/text.py
+++ b/pyterrier/text.py
@@ -177,7 +177,7 @@ def sliding( text_attr='body', length=150, stride=75, join=' ', prepend_attr='ti
         prepend_attr(str): whether another document attribute, such as the title of the document, to each passage, following [Dai2019]. Defaults to 'title'. 
         title_attr(str): what is the name of the dataframe attribute containing the title the document to be split into passages.
             Default is 'title'. Only used if prepend_title is set to True.
-        tokenizer(obj): which model to use for tokenizing. the object must have a `.tokenize(str) -> list[str]` method for tokenization.
+        tokenizer(obj): which model to use for tokenizing. The object must have a `.tokenize(str) -> list[str]` method for tokenization and `.convert_tokens_to_string(list[str]) -> str` for detokenization.
             Default is None. Tokenisation is perfomed by splitting on one-or-more spaces, i.e. based on the Python regular expression ``re.compile(r'\s+')``
     
     Example::
@@ -409,17 +409,8 @@ class SlidingWindowPassager(Transformer):
 
         # check if the tokenizer has the `.tokenize()` and the `.convert_tokens_to_string()` method
         if self.tokenizer is not None:
-            tokenizer_attr = getattr(self.tokenizer, 'tokenize', False)
-            if not tokenizer_attr or not callable(tokenizer_attr):
-                raise TypeError("%s doesn't have a `tokenize(str) -> list[str]` method. The tokenizer must have `tokenize(str) -> list[str]` method.")
-            else:
-                self.tokenize = self.tokenizer.tokenize
-            
-            convert_to_string_attr = getattr(self.tokenizer, 'convert_tokens_to_string', False)
-            if not convert_to_string_attr or not callable(convert_to_string_attr):
-                raise TypeError("%s doesn't have a `convert_tokens_to_string(list[str]) -> str` method. The tokenizer must have `convert_tokens_to_string(list[str]) -> str` method.")
-            else:
-                self.detokenize = self.tokenizer.convert_tokens_to_string
+            self.tokenize = self.tokenizer.tokenize
+            self.detokenize = self.tokenizer.convert_tokens_to_string
         else:
             self.tokenize = re.compile(r"\s+").split
             self.detokenize = ' '.join

--- a/pyterrier/text.py
+++ b/pyterrier/text.py
@@ -432,15 +432,11 @@ class SlidingWindowPassager(Transformer):
         return self.applyPassaging_no_qid(topics_and_res)
 
     def applyPassaging_no_qid(self, df):
-        if self.tokenizer is None:
-            p = re.compile(r"\s+")
+        tokenize = re.compile(r"\s+").split if self.tokenizer is None else self.tokenizer.tokenize
         rows=[]
         for row in df.itertuples():
             row = row._asdict()
-            if self.tokenizer is None:
-                toks = p.split(row[self.text_attr])
-            else:
-                toks = self.tokenizer.tokenize(row[self.text_attr])
+            toks = tokenize(row[self.text_attr])
             if len(toks) < self.passage_length:
                 row['docno'] = row['docno'] + "%p0"
                 row[self.text_attr] = ' '.join(toks)
@@ -465,8 +461,7 @@ class SlidingWindowPassager(Transformer):
     def applyPassaging(self, df, labels=True):
         newRows=[]
         labelCount=defaultdict(int)
-        if self.tokenizer is None:
-            p = re.compile(r"\s+")
+        tokenize = re.compile(r"\s+").split if self.tokenizer is None else self.tokenizer.tokenize
         currentQid=None
         rank=0
         copy_columns=[]
@@ -486,10 +481,7 @@ class SlidingWindowPassager(Transformer):
                     rank=0
                     currentQid = qid
                 rank+=1
-                if self.tokenizer is None:
-                    toks = p.split(row[self.text_attr])
-                else:
-                    toks = self.tokenizer.tokenize(row[self.text_attr])
+                toks = tokenize(row[self.text_attr])
                 if len(toks) < self.passage_length:
                     newRow = row.copy()
                     newRow['docno'] = row['docno'] + "%p0"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ ray
 fastrank>=0.7.0
 torch
 lz4
+transformers

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -139,10 +139,12 @@ class TestText(BaseTestCase):
 
     def test_passager_custom_tokenizer(self):
         class MockTokenizer:
-            @staticmethod
-            def tokenize(input_str):
+            def tokenize(self, input_str):
                 rx = r"\w+(?:\"\w+)?|[^\w\s]"
                 return re.findall(rx, input_str)
+            
+            def convert_tokens_to_string(self, input_toks):
+                return ' '.join(input_toks)
     
         dfinput = pd.DataFrame([["q1", "a query", "doc1", "it's a sample document!"]], columns=["qid", "query", "docno", "body"])
         passager = pt.text.sliding(length=4, stride=3, prepend_attr=None, tokenizer=MockTokenizer())
@@ -153,6 +155,24 @@ class TestText(BaseTestCase):
 
         self.assertEqual("it ' s a", dfoutput["body"][0])
         self.assertEqual("a sample document !", dfoutput["body"][1])
+
+    def test_passager_HGF(self):
+        try: 
+            from transformers import AutoTokenizer
+        except:
+            self.skipTest("`transformers` not installed")
+        
+        tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+        dfinput = pd.DataFrame([["q1", "a query", "doc1", "it's a sample document!"]], columns=["qid", "query", "docno", "body"])
+        passager = pt.text.sliding(length=4, stride=3, prepend_attr=None, tokenizer=tokenizer)
+        dfoutput = passager(dfinput)
+        self.assertEqual(2, len(dfoutput))
+        self.assertEqual("doc1%p0", dfoutput["docno"][0])
+        self.assertEqual("doc1%p1", dfoutput["docno"][1])
+
+        self.assertEqual("it ' s a", dfoutput["body"][0])
+        self.assertEqual("a sample document!", dfoutput["body"][1])
+
 
     def test_depassager(self):
         dfinput = pd.DataFrame([["q1", "a query", "doc1", 1, "title", "body sentence"]], columns=["qid", "query", "docno", "docid", "title", "body"])


### PR DESCRIPTION
For the purposes of obtaining passages of a given length, tokenisation is performed by using the `tokenizer` object passed as an argument. The `tokenizer` object must have a `.tokenize(str) -> list[str]` method. By default, tokenisation is performed by splitting on one-or-more spaces, i.e. based on the Python regular expression ``re.compile(r'\s+')``.

Example
```python
from transformers import AutoTokenizer
tok = AutoTokenizer.from_pretrained("bert-base-uncased")
pipe = (pt.BatchRetrieve(index, wmodel="DPH", metadata=["docno", "body"])
      >> pt.text.sliding(length=128, stride=64, prepend_attr=None, tokenizer=tok)
      >> pt.text.scorer(wmodel="DPH")
      >> pt.text.max_passage() )
```