### PR TITLE
fix parsing of trecxml topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,4 @@ By downloading and using PyTerrier, you agree to cite at the undernoted paper de
  - Sarawoot Kongyoung, University of Glasgow
  - Zhan Su, Copenhagen University
  - Marcus Schutte, TU Delft
+ - Lukas Zeit-Altpeter, Friedrich Schiller University Jena

--- a/pyterrier/io.py
+++ b/pyterrier/io.py
@@ -305,7 +305,6 @@ def read_topics(filename, format="trec", **kwargs):
 
 def _read_topics_trec(file_path, doc_tag="TOP", id_tag="NUM", whitelist=["TITLE"], blacklist=["DESC","NARR"]):
     from jnius import autoclass
-
     from . import check_version
     assert check_version("5.3")
     trecquerysource = autoclass('org.terrier.applications.batchquerying.TRECQuery')
@@ -332,7 +331,6 @@ def _read_topics_trecxml(filename, tags=["query", "question", "narrative"], toke
         pandas.Dataframe with columns=['qid','query']
     """
     import xml.etree.ElementTree as ET
-
     import pandas as pd
     tags=set(tags)
     topics=[]

--- a/pyterrier/io.py
+++ b/pyterrier/io.py
@@ -296,7 +296,7 @@ def read_topics(filename, format="trec", **kwargs):
 
     Supported Formats:
         * "trec" -- an SGML-formatted TREC topics file. Delimited by TOP tags, each having NUM and TITLE tags; DESC and NARR tags are skipped by default. Control using whitelist and blacklist kwargs
-        * "trecxml" -- a more modern XML formatted topics file. Delimited by topic tags, each having nunber tags. query, question and narrative tags are parsed by default. Control using tags kwarg.
+        * "trecxml" -- a more modern XML formatted topics file. Delimited by topic tags, each having number tags. query, question and narrative tags are parsed by default. Control using tags kwarg.
         * "singeline" -- one query per line, preceeded by a space or colon. Tokenised by default, use tokenise=False kwargs to prevent tokenisation.
     """
     if format is None:

--- a/pyterrier/io.py
+++ b/pyterrier/io.py
@@ -1,7 +1,6 @@
 import os
-from contextlib import contextmanager
-
 import pandas as pd
+from contextlib import contextmanager
 
 
 def coerce_dataframe(obj):
@@ -197,7 +196,6 @@ def _read_results_letor(filename, labels=False):
             # my %hash = map {split /:/, $_} @parts;
             # return ($label, $comment, %hash);
         import re
-
         import numpy as np
         line, comment = l.split("#")
         line = line.strip()
@@ -371,7 +369,6 @@ def _read_topics_singleline(filepath, tokenise=True):
     """
     rows = []
     from jnius import autoclass
-
     from . import check_version
     assert check_version("5.3")
     slqIter = autoclass("org.terrier.applications.batchquerying.SingleLineTRECQuery")(filepath, tokenise)

--- a/tests/fixtures/topics.trecxml
+++ b/tests/fixtures/topics.trecxml
@@ -11,6 +11,7 @@
     <description>Description radiowaves</description>
     <narrative>Documents are relevant if they describe radiowaves.</narrative>
   </topic>
+  <!-- Use attribute rather than tag for number -->
   <topic number="3">
     <title>sounds</title>
     <description>Description sound</description>

--- a/tests/fixtures/topics.trecxml
+++ b/tests/fixtures/topics.trecxml
@@ -1,0 +1,19 @@
+<topics>
+  <topic>
+    <number>1</number>
+    <title>lights</title>
+    <description>Description lights</description>
+    <narrative>Documents are relevant if they describe lights.</narrative>
+  </topic>
+  <topic>
+    <number>2</number>
+    <title>radiowaves</title>
+    <description>Description radiowaves</description>
+    <narrative>Documents are relevant if they describe radiowaves.</narrative>
+  </topic>
+  <topic number="3">
+    <title>sounds</title>
+    <description>Description sound</description>
+    <narrative>Documents are relevant if they describe sounds.</narrative>
+  </topic>
+</topics>

--- a/tests/test_topicsparsing.py
+++ b/tests/test_topicsparsing.py
@@ -1,14 +1,19 @@
-import pyterrier as pt
-import unittest
-from .base import BaseTestCase
 import os
+import unittest
+
 import pandas as pd
 
-class TestTopicsParsing(BaseTestCase):
+import pyterrier as pt
 
+from .base import BaseTestCase
+
+
+class TestTopicsParsing(BaseTestCase):
     def testSingleLine(self):
         topics = pt.io.read_topics(
-            os.path.dirname(os.path.realpath(__file__)) + "/fixtures/singleline.topics", format="singleline")
+            os.path.dirname(os.path.realpath(__file__)) + "/fixtures/singleline.topics",
+            format="singleline",
+        )
         self.assertEqual(2, len(topics))
         self.assertTrue("qid" in topics.columns)
         self.assertTrue("query" in topics.columns)
@@ -19,12 +24,29 @@ class TestTopicsParsing(BaseTestCase):
 
     def test_parse_trec_topics_file_T(self):
         input = os.path.dirname(os.path.realpath(__file__)) + "/fixtures/topics.trec"
-        exp_result = pd.DataFrame([["1", "light"], ["2", "radiowave"], ["3", "sound"]], columns=['qid', 'query'])
+        exp_result = pd.DataFrame(
+            [["1", "light"], ["2", "radiowave"], ["3", "sound"]],
+            columns=["qid", "query"],
+        )
         result = pt.io.read_topics(input)
         self.assertTrue(exp_result.equals(result))
 
     def test_parse_trec_topics_file_D(self):
         input = os.path.dirname(os.path.realpath(__file__)) + "/fixtures/topics.trec"
-        exp_result = pd.DataFrame([["1", "lights"], ["2", "radiowaves"], ["3", "sounds"]], columns=['qid', 'query'])
-        result = pt.io.read_topics(input, format="trec", whitelist=["DESC"], blacklist=["TITLE"])
+        exp_result = pd.DataFrame(
+            [["1", "lights"], ["2", "radiowaves"], ["3", "sounds"]],
+            columns=["qid", "query"],
+        )
+        result = pt.io.read_topics(
+            input, format="trec", whitelist=["DESC"], blacklist=["TITLE"]
+        )
+        self.assertTrue(exp_result.equals(result))
+
+    def test_parse_trecxml_topics_file(self):
+        input = os.path.dirname(os.path.realpath(__file__)) + "/fixtures/topics.trecxml"
+        result = pt.io.read_topics(input, format="trecxml", tags=["title"])
+        exp_result = pd.DataFrame(
+            [["1", "lights"], ["2", "radiowaves"], ["3", "sounds"]],
+            columns=["qid", "query"],
+        )
         self.assertTrue(exp_result.equals(result))


### PR DESCRIPTION
The current implementation of `_read_topics_trecxml` is expecting the topic number to be supplied via attribute to the topic tag. However, this does not seem to be the current way TREC is formatting topics in xml. See for example the [health misinfo topics](https://trec.nist.gov/data/misinfo/misinfo-2021-topics.xml):
```
<topic>
<number>101</number>
<query>ankle brace achilles tendonitis</query>
<description>
Will wearing an ankle brace help heal achilles tendonitis?
</description>
<narrative>
Achilles tendonitis is a condition where one experiences pain in the Achilles tendon located near the heel. An ankle brace is usually worn around the ankles to protect and limit movement. A very useful document would discuss the effectiveness of using ankle braces to help heal Achilles tendonitis. A useful document would help a user make a decision about the use of ankle braces for treating tendonitis by providing information about recommended treatments for Achilles tendonitis, ankle braces, or both.
</narrative>
<disclaimer>
We do not claim to be providing medical advice, and medical decisions should never be made based on the stance we have chosen. Consult a medical doctor for professional advice.
</disclaimer>
<stance>unhelpful</stance>
<evidence>
https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3134723/
</evidence>
</topic>
```

My change should not break backwards compatibility, also added a test to confirm this (see topic 3 still using an attribute to set the number).