### PR TITLE
Fix typo in Learning to Rank Examples.ipynb

### DIFF
--- a/examples/notebooks/ltr.ipynb
+++ b/examples/notebooks/ltr.ipynb
@@ -769,7 +769,7 @@
         "\n",
         "Our first learning-to-rank will be done using sci-kit learn's [RandomForestRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.html). \n",
         "\n",
-        "We use `pt.piptlines.LTR_pipeline`, which is a pyterrier transformer that passes the document features as \"X\" features to RandomForest. To learn the model (called fitting) the RandomForest, we invoke the `fit()` method - on the entire pipeline, specifying the queries (topics) and relevance assessment (qrels). The latter for the \"Y\" labels for the RandomForest fitting.\n",
+        "We use `pt.pipelines.LTR_pipeline`, which is a pyterrier transformer that passes the document features as \"X\" features to RandomForest. To learn the model (called fitting) the RandomForest, we invoke the `fit()` method - on the entire pipeline, specifying the queries (topics) and relevance assessment (qrels). The latter for the \"Y\" labels for the RandomForest fitting.\n",
         "\n",
         "NB: due to their bootstrap nature, Random Forests do not overfit, so we do not provide validation data to `fit()`.\n",
         "\n",


### PR DESCRIPTION
 Changes `pt.piptlines.LTR_pipeline` to `pt.pipelines.LTR_pipeline`