### PR TITLE
improved error message pt.apply.query - from #433

### DIFF
--- a/pyterrier/apply_base.py
+++ b/pyterrier/apply_base.py
@@ -210,11 +210,18 @@ class ApplyQueryTransformer(ApplyTransformerBase):
             outputRes = push_queries(inputRes.copy(), inplace=True, keep_original=True)
         else:
             outputRes = inputRes.copy()
-        if self.verbose:
-            tqdm.pandas(desc="pt.apply.query", unit="d")
-            outputRes["query"] = outputRes.progress_apply(fn, axis=1)
-        else:
-            outputRes["query"] = outputRes.apply(fn, axis=1)
+        try:
+            if self.verbose:
+                tqdm.pandas(desc="pt.apply.query", unit="d")
+                outputRes["query"] = outputRes.progress_apply(fn, axis=1)
+            else:
+                outputRes["query"] = outputRes.apply(fn, axis=1)
+        except ValueError as ve:
+            msg = str(ve)
+            if "Columns must be same length as key" in msg:
+                raise TypeError("Could not coerce return from pt.apply.query function into a list of strings. Check your function returns a string.") from ve
+            else:
+                raise ve
         return outputRes
 
 class ApplyGenericTransformer(ApplyTransformerBase):

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -59,6 +59,14 @@ class TestApply(BaseTestCase):
         rtrDR2 = pt.apply.query(lambda row : row["qid"] )(testDF2)
         self.assertEqual(rtrDR2.iloc[0]["query"], "q1")
 
+    def test_query_apply_error(self):
+        origquery="the bear and the wolf"
+        testDF = pd.DataFrame([["q1", origquery]], columns=["qid", "query"])
+        p = pt.apply.query(lambda q : q) # should thrown an error, as pt.apply.query should return a string, not a row
+        with self.assertRaises(TypeError) as te:
+            p(testDF)
+        self.assertTrue("Could not coerce return from pt.apply.query function into a list of strings" in str(te.exception))
+
     def test_by_query_apply(self):
         inputDf = pt.new.ranked_documents([[1], [2]], qid=["1", "2"])
         def _inc_score(res):


### PR DESCRIPTION
Suggestion to improve researcher experience, as experienced by @bakingeol.

`pt.apply.query` is a wrapper around Pandas apply. If the applied function does not return a string, Pandas error message can be confusing: _"ValueError: Columns must be same length as key"_

This PR provides a TypeError on top that provides a more useful error message:
`TypeError("Could not coerce return from pt.apply.query function into a list of strings. Check your function returns a string.")`