### PR TITLE
Delete baseline pvalue from correction method input

### DIFF
--- a/pyterrier/pipelines.py
+++ b/pyterrier/pipelines.py
@@ -561,7 +561,7 @@ def Experiment(
             for pcol in p_col_names:
                 pcol_reject = pcol.replace("p-value", "reject")
                 pcol_corrected = pcol + " corrected"                
-                reject, corrected, _, _ = statsmodels.stats.multitest.multipletests(df[pcol].drop(baseline), alpha=correction_alpha, method=correction)
+                reject, corrected, _, _ = statsmodels.stats.multitest.multipletests(df[pcol].drop(df.index[baseline]), alpha=correction_alpha, method=correction)
                 insert_pos = df.columns.get_loc(pcol)
                 # add reject/corrected values for the baseline
                 reject = np.insert(reject, baseline, False)

--- a/pyterrier/pipelines.py
+++ b/pyterrier/pipelines.py
@@ -561,8 +561,11 @@ def Experiment(
             for pcol in p_col_names:
                 pcol_reject = pcol.replace("p-value", "reject")
                 pcol_corrected = pcol + " corrected"                
-                reject, corrected, _, _ = statsmodels.stats.multitest.multipletests(df[pcol], alpha=correction_alpha, method=correction)
+                reject, corrected, _, _ = statsmodels.stats.multitest.multipletests(df[pcol].drop(baseline), alpha=correction_alpha, method=correction)
                 insert_pos = df.columns.get_loc(pcol)
+                # add reject/corrected values for the baseline
+                reject = np.insert(reject, baseline, False)
+                corrected = np.insert(corrected, baseline, np.nan)
                 # add extra columns, put place directly after the p-value column
                 df.insert(insert_pos+1, pcol_reject, reject)
                 df.insert(insert_pos+2, pcol_corrected, corrected)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -363,15 +363,17 @@ class TestExperiment(TempDirTestCase):
         dataset = pt.get_dataset("vaswani")
         res1 = pt.BatchRetrieve(dataset.get_index(), wmodel="BM25")(dataset.get_topics().head(10))
         res2 = pt.BatchRetrieve(dataset.get_index(), wmodel="DPH")(dataset.get_topics().head(10))
-        for corr in ['hs', 'bonferroni', 'holm-sidak']:            
+        baseline = 0
+        for corr in ['hs', 'bonferroni', 'hommel']:
             df = pt.Experiment(
                 [res1, res2], 
                 dataset.get_topics().head(10), 
                 dataset.get_qrels(),
                 eval_metrics=["map", "ndcg"], 
-                baseline=0, correction='hs')
+                baseline=baseline, correction=corr)
             self.assertTrue("map +" in df.columns)
             self.assertTrue("map -" in df.columns)
             self.assertTrue("map p-value" in df.columns)
             self.assertTrue("map p-value corrected" in df.columns)
             self.assertTrue("map reject" in df.columns)
+            self.assertFalse(any(df["map p-value corrected"].drop(df.index[baseline]).isna()))


### PR DESCRIPTION
**Issue:** 
When performing the significance test correction the p-value for the baseline (NaN) is included in the p-values list, therefore corrected p-values are not right.

**Code to reproduce the error:**
```python
import pyterrier as pt 

from pyterrier.measures import *
from pyterrier_pisa import PisaIndex


pt.init()

dataset = pt.get_dataset('irds:msmarco-passage/trec-dl-2019/judged')

index = PisaIndex.from_dataset('msmarco_passage')
bm25 = index.bm25(num_results=1000)
dph = index.dph()
pl2 = index.pl2(c=1.0)

res = pt.Experiment(
	[bm25, dph, pl2],
	dataset.get_topics(),
	dataset.get_qrels(),
	eval_metrics=[RR(rel=2)@10], # type: ignore
	batch_size=1024,
	drop_unused=True,
	names = ["bm25", "dph", "pl2"],
	round=4,
	baseline=0,
	correction="hommel",
)
```

**Output:**
```
   name  RR(rel=2)@10  RR(rel=2)@10 +  RR(rel=2)@10 -  RR(rel=2)@10 p-value  RR(rel=2)@10 reject  RR(rel=2)@10 p-value corrected
0  bm25        0.6780             NaN             NaN                   NaN                False                             NaN
1   dph        0.6624             6.0             8.0              0.512930                False                             NaN
2   pl2        0.6452             5.0            11.0              0.433652                False                             NaN
```

**Expected output:**
```
   name  RR(rel=2)@10  RR(rel=2)@10 +  RR(rel=2)@10 -  RR(rel=2)@10 p-value  RR(rel=2)@10 reject  RR(rel=2)@10 p-value corrected
0  bm25        0.6780             NaN             NaN                   NaN                False                             NaN
1   dph        0.6624             6.0             8.0              0.512930                False                         0.51293
2   pl2        0.6452             5.0            11.0              0.433652                False                         0.51293
```

This example is clarifying as we are using Hommel as the correction method which does not allow NaN values, however, it applies to other corrections as well.

**Proposed solution:**
I propose dropping the baseline p-value from the dataframe column which is used as the input for the `multipletests` function and then inserting default values on the `reject` and `corrected` ndarrays for it.