### PR TITLE
Add PyTerrier_ChatNoir to the plugin section

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ Welcome to PyTerrier's documentation!
    PyTerrier_T5 <https://github.com/terrierteam/pyterrier_t5>
    PyTerrier_GenRank <https://github.com/emory-irlab/pyterrier_genrank>
    PyTerrier_ColBERT <https://github.com/terrierteam/pyterrier_colbert>
+   PyTerrier_ChatNoir <https://github.com/chatnoir-eu/chatnoir-pyterrier>
    PyTerrier_ANCE <https://github.com/terrierteam/pyterrier_ance>
    PyTerrier_doc2query <https://github.com/terrierteam/pyterrier_doc2query>
    PyTerrier_DeepCT <https://github.com/terrierteam/pyterrier_deepct>


### PR DESCRIPTION
Dear all,

we have a PyTerrier plugin for ChatNoir (cf. the [paper](https://webis.de/publications.html?q=ChatNoir#bevendorff_2018), respectively [an example query](https://chatnoir.web.webis.de/?q=Do+Goldfish+grow&index=msmarco-v2.1&p=1) to allow retrieval/re-ranking against large datasets (e.g., ClueWeb09, ClueWeb12, ClueWeb22, the recent MS MARCO V2.1 inclusion is in progress for TREC RAG) that we would like to add to the documentation of available plugins. With this plugin, users can re-rank the results without having to index the corpora themselves.

The covered parts of the REST API allows for retrieval and for random-document access (but this random document access is much slower compared to a locally available ir_dataset, but is still valuable I think, for example when users do not want to download the complete datasets but still apply re-ranking pipelines).


In the next weeks, I would like to add more of the public ir_datasets to ChatNoir, which could make this plugin really cool I think.


