### PR TITLE
Deprecate DFIndexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ PyTerrier has a number of useful classes for creating indices:
 
  - You can create an index from TREC formatted collection using [TRECCollectionIndexer](https://pyterrier.readthedocs.io/en/latest/terrier-indexing.html#treccollectionindexer).    
  - For TXT, PDF, Microsoft Word files, etc files you can use [FilesIndexer](https://pyterrier.readthedocs.io/en/latest/terrier-indexing.html#filesindexer).
- - For Pandas Dataframe you can use [DFIndexer](https://pyterrier.readthedocs.io/en/latest/terrier-indexing.html#dfindexer).
- - For any abitrary iterable dictionaries, you can use [IterDictIndexer](https://pyterrier.readthedocs.io/en/latest/terrier-indexing.html#iterdictindexer).
+ - For any abitrary iterable dictionaries or a Pandas Dataframe, you can use [IterDictIndexer](https://pyterrier.readthedocs.io/en/latest/terrier-indexing.html#iterdictindexer).
 
 See the [indexing documentation](https://pyterrier.readthedocs.io/en/latest/terrier-indexing.html), or the examples in the [indexing notebook](examples/notebooks/indexing.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/terrier-org/pyterrier/blob/master/examples/notebooks/indexing.ipynb)
 

--- a/docs/terrier-indexing.rst
+++ b/docs/terrier-indexing.rst
@@ -10,8 +10,7 @@ There are four indexer classes:
 
  - You can create an index from TREC-formatted files, from a TREC test collection, using ``TRECCollectionIndexer``.
  - For indexing TXT, PDF, Microsoft Word files, etc files you can use ``FilesIndexer``.
- - For indexing Pandas Dataframe you can use ``DFIndexer``.
- - For any abitrary iterable dictionaries, you can use ``IterDictIndexer``.
+ - For any abitrary iterable dictionaries, or a Pandas Dataframes, you can use ``IterDictIndexer``.
 
 There are also different types of indexing supported in Terrier that are exposed in PyTerrier. We explain both the indexing types and the indexer classes below, with examples. Further worked examples of indexing are provided in the `example indexing notebook <https://github.com/terrier-org/pyterrier/blob/master/examples/notebooks/indexing.ipynb>`_.
 
@@ -48,31 +47,6 @@ FilesIndexer
 
 .. autoclass:: pyterrier.terrier.FilesIndexer
    :members: index
-
-DFIndexer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: pyterrier.terrier.DFIndexer
-   :members: index
-
-Example indexing a dataframe::
-
-    # define an example dataframe of documents
-    import pandas as pd
-    df = pd.DataFrame({ 
-        'docno':
-        ['1', '2', '3'],
-        'url': 
-        ['url1', 'url2', 'url3'],
-        'text': 
-        ['He ran out of money, so he had to stop playing',
-        'The waves were crashing on the shore; it was a',
-        'The body may perhaps compensates for the loss']
-    })
-
-    # index the text, record the docnos as metadata
-    pd_indexer = pt.DFIndexer("./pd_index")
-    indexref = pd_indexer.index(df["text"], df["docno"])
 
 
 IterDictIndexer

--- a/examples/notebooks/indexing.ipynb
+++ b/examples/notebooks/indexing.ipynb
@@ -26,7 +26,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -36,7 +36,15 @@
         "id": "JWLqWXBHeBRc",
         "outputId": "04d8b4fa-7e60-4ccc-ad6b-3b95f0445437"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Note: you may need to restart the kernel to use updated packages.\n"
+          ]
+        }
+      ],
       "source": [
         "%pip install -q python-terrier"
       ]
@@ -57,7 +65,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": 2,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -86,7 +94,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 3,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -113,7 +121,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 4,
       "metadata": {
         "colab": {},
         "colab_type": "code",
@@ -131,13 +139,14 @@
         "id": "gjsYdSDvOTi_"
       },
       "source": [
-        "Create `pt.TRECCollectionIndexer` object    \n",
-        "index_path argument specifies where to store the index"
+        "Create `pt.TRECCollectionIndexer` object:\n",
+        " - `index_path` argument specifies where to store the index\n",
+        " - `blocks` argument specifies whether term positions should be recorded in the index or not. These are used for phrasal (`\"\"`) queries or applying term proximity ranking models. "
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 5,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -153,11 +162,11 @@
           "output_type": "stream",
           "text": [
             "SLF4J: Class path contains multiple SLF4J bindings.\n",
-            "SLF4J: Found binding in [jar:file:/Users/craigm/opt/anaconda3/lib/python3.9/site-packages/pyserini/resources/jars/anserini-0.22.0-fatjar.jar!/org/slf4j/impl/StaticLoggerBinder.class]\n",
             "SLF4J: Found binding in [jar:file:/Users/craigm/.m2/repository/org/terrier/terrier-assemblies/5.9/terrier-assemblies-5.9-jar-with-dependencies.jar!/org/slf4j/impl/StaticLoggerBinder.class]\n",
+            "SLF4J: Found binding in [jar:file:/Users/craigm/opt/anaconda3/lib/python3.9/site-packages/pyserini/resources/jars/anserini-0.22.0-fatjar.jar!/org/slf4j/impl/StaticLoggerBinder.class]\n",
             "SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.\n",
-            "SLF4J: Actual binding is of type [org.slf4j.impl.SimpleLoggerFactory]\n",
-            "Java started (triggered by TerrierIndexer.__init__) and loaded: pyterrier.java, pyterrier.anserini.java [version=0.22.0 (from pyserini package)], pyterrier.terrier.java [version=5.9 (build: craigm 2024-05-02 17:40), helper_version=0.0.8 prf_version=-SNAPSHOT]\n"
+            "SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]\n",
+            "Java started (triggered by TerrierIndexer.__init__) and loaded: pyterrier.java, pyterrier.terrier.java [version=5.9 (build: craigm 2024-05-02 17:40), helper_version=0.0.8 prf_version=-SNAPSHOT], pyterrier.anserini.java [version=0.22.0 (from pyserini package)]\n"
           ]
         }
       ],
@@ -178,44 +187,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 6,
       "metadata": {
         "colab": {},
         "colab_type": "code",
         "id": "l3C3NLUwQq0p"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[main] INFO org.terrier.indexing.MultiDocumentFileCollection - TRECCollection 0% processing /Users/craigm/.pyterrier/corpora/vaswani/corpus/doc-text.trec\n",
-            "[main] INFO org.terrier.structures.indexing.Indexer - creating the data structures data_1\n",
-            "[main] INFO org.terrier.structures.indexing.LexiconBuilder - LexiconBuilder active - flushing every 100000 documents, or when memory threshold hit\n",
-            "[main] INFO org.terrier.structures.indexing.BaseMetaIndexBuilder - ZstdMetaIndexBuilder meta achieved compression ratio 3.0456963 (> 1 is better)\n",
-            "[main] INFO org.terrier.structures.indexing.LexiconBuilder - 1 lexicons to merge\n",
-            "[main] INFO org.terrier.structures.indexing.LexiconBuilder - Optimising structure lexicon\n",
-            "[main] INFO org.terrier.structures.indexing.FSOMapFileLexiconUtilities - Optimising lexicon with 7756 entries\n",
-            "[main] INFO org.terrier.structures.indexing.Indexer - Started building the block inverted index...\n",
-            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - creating block inverted index\n",
-            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - BlockMemSizeLexiconScanner: lexicon scanning until approx 6.2 GiB of memory, including positions, is consumed\n",
-            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - Iteration 1 of 2 (estimated) iterations\n",
-            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - time to process part of lexicon: 0.027\n",
-            "[main] INFO org.terrier.structures.FSADocumentIndex - Document index requires 44.6 KiB remaining heap is 7.9 GiB\n",
-            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - time to traverse direct file: 0.114\n",
-            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - time to write inverted file: 0.046\n",
-            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - temporary memory used: 3.6 MiB\n",
-            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - time to perform one iteration: 0.192\n",
-            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - number of pointers processed: 224573\n",
-            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - Finished generating inverted file, rewriting lexicon\n",
-            "[main] INFO org.terrier.structures.indexing.LexiconBuilder - Optimising structure lexicon\n",
-            "[main] INFO org.terrier.structures.indexing.FSOMapFileLexiconUtilities - Optimising lexicon with 7756 entries\n",
-            "[main] INFO org.terrier.structures.indexing.Indexer - Finished building the block inverted index...\n",
-            "[main] INFO org.terrier.structures.indexing.Indexer - Time elapsed for inverted file: 0\n",
-            "[main] INFO org.terrier.structures.indexing.Indexer - Collection took 2 seconds to index (11429 documents)\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "indexref = indexer.index(dataset.get_corpus())\n",
         "\n",
@@ -238,7 +216,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 7,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -255,7 +233,7 @@
               "'./index/data.properties'"
             ]
           },
-          "execution_count": 6,
+          "execution_count": 7,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -276,7 +254,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 8,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -287,23 +265,6 @@
         "outputId": "180e7910-274e-4b08-d974-da47033d4e87"
       },
       "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[main] INFO org.terrier.structures.FSADocumentIndex - Document index requires 44.6 KiB remaining heap is 7.9 GiB\n",
-            "[Thread-2] INFO org.terrier.utility.TerrierTimer - Loading document document lengths 1% done. Estimated finished in 0m00s\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta reading lookup file into memory\n",
-            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta reading reverse map for key docno directly from disk\n",
-            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta loading data file into memory\n"
-          ]
-        },
         {
           "name": "stdout",
           "output_type": "stream",
@@ -348,7 +309,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 9,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -370,7 +331,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 10,
       "metadata": {
         "colab": {},
         "colab_type": "code",
@@ -433,7 +394,7 @@
               "2     3  url3   The body may perhaps compensates for the loss"
             ]
           },
-          "execution_count": 11,
+          "execution_count": 10,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -466,36 +427,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 11,
       "metadata": {
         "colab": {},
         "colab_type": "code",
         "id": "rBXHWO4yUJT7"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.Indexer - Indexer using 1 fields\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.Indexer - creating the data structures data_stream0_1\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - LexiconBuilder active - flushing every 100000 documents, or when memory threshold hit\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.BaseMetaIndexBuilder - ZstdMetaIndexBuilder meta achieved compression ratio 3.5882354 (> 1 is better)\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - 1 lexicons to merge\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - Optimising structure lexicon\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.FSOMapFileLexiconUtilities - Optimising lexicon with 10 entries\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.Indexer - Started building the inverted index...\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - BasicMemSizeLexiconScanner: lexicon scanning until approx 6.2 GiB of memory is consumed\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - Iteration 1 of 1 (estimated) iterations\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - Optimising structure lexicon\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - lexicon has 1 fields\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.FSOMapFileLexiconUtilities - Optimising lexicon with 10 entries\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.Indexer - Finished building the inverted index...\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.Indexer - Time elapsed for inverted file: 0\n",
-            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.Indexer - Collection took 0 seconds to index (3 documents)\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# no metadata\n",
         "# pd_indexer.index(df[\"text\"])\n",
@@ -523,7 +461,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 12,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -535,56 +473,16 @@
       },
       "outputs": [
         {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.Indexer - Indexer using 1 fields\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.Indexer - creating the data structures data_stream0_1\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - LexiconBuilder active - flushing every 100000 documents, or when memory threshold hit\n"
-          ]
-        },
-        {
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "processing document 0\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[ForkJoinPool-2-worker-1] WARN org.terrier.structures.indexing.Indexer - Adding an empty document to the index (730691_1) - further warnings are suppressed\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
+            "processing document 0\n",
+            "16:05:44.835 [ForkJoinPool-2-worker-1] WARN org.terrier.structures.indexing.Indexer - Adding an empty document to the index (730691_1) - further warnings are suppressed\n",
             "processing document 100000\n",
             "processing document 200000\n",
             "processing document 300000\n",
-            "processing document 400000\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.BaseMetaIndexBuilder - ZstdMetaIndexBuilder meta achieved compression ratio 2.4496965 (> 1 is better)\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - 5 lexicons to merge\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - Optimising structure lexicon\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.FSOMapFileLexiconUtilities - Optimising lexicon with 132468 entries\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.Indexer - Started building the inverted index...\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - BasicMemSizeLexiconScanner: lexicon scanning until approx 6.1 GiB of memory is consumed\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - Iteration 1 of 1 (estimated) iterations\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - Optimising structure lexicon\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - lexicon has 1 fields\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.FSOMapFileLexiconUtilities - Optimising lexicon with 132468 entries\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.Indexer - Finished building the inverted index...\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.Indexer - Time elapsed for inverted file: 2\n",
-            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.Indexer - Collection took 35 seconds to index (403666 documents)\n",
-            "[ForkJoinPool-2-worker-1] WARN org.terrier.structures.indexing.Indexer - Indexed 2224 empty documents\n"
+            "processing document 400000\n",
+            "16:06:10.750 [ForkJoinPool-2-worker-1] WARN org.terrier.structures.indexing.Indexer - Indexed 2224 empty documents\n"
           ]
         }
       ],
@@ -630,7 +528,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 13,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -641,28 +539,6 @@
         "outputId": "11b3b274-2921-4663-f91b-9ef711376582"
       },
       "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[main] INFO org.terrier.querying.LocalManager - Starting to execute query 1 - mathematical\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process TerrierQLParser\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process TerrierQLToControls\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process TerrierQLToMatchingQueryTerms\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process ApplyTermPipeline(termpipelines=Stopwords,PorterStemmer)\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process ApplyLocalMatching\n",
-            "[main] INFO org.terrier.structures.FSADocumentIndex - Document index requires 44.6 KiB remaining heap is 7.9 GiB\n",
-            "[Thread-5] INFO org.terrier.utility.TerrierTimer - Loading document document lengths 3% done. Estimated finished in 0m00s\n",
-            "[main] INFO org.terrier.querying.LocalManager - mathemat { req=null, w=1.0, stats=null, models=[org.terrier.matching.models.DPH@5f3b9c57] tags=[firstmatchscore]} \n",
-            "[main] INFO org.terrier.matching.PostingListManager - Query 1 with 1 terms has 1 posting lists\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process PostFilterProcess\n",
-            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta reading lookup file into memory\n",
-            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta reading reverse map for key docno directly from disk\n",
-            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta loading data file into memory\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process SimpleDecorateProcess\n",
-            "[main] INFO org.terrier.querying.LocalManager - Finished executing query 1 in 129ms - 152 results retrieved\n"
-          ]
-        },
         {
           "data": {
             "text/html": [
@@ -814,7 +690,7 @@
               "[152 rows x 6 columns]"
             ]
           },
-          "execution_count": 14,
+          "execution_count": 13,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -835,7 +711,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 14,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -846,28 +722,6 @@
         "outputId": "6a4e7e45-eaa4-48a0-d069-b271e3554826"
       },
       "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[main] INFO org.terrier.querying.LocalManager - Starting to execute query 2 - mathematical\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process TerrierQLParser\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process TerrierQLToControls\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process TerrierQLToMatchingQueryTerms\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process ApplyTermPipeline(termpipelines=Stopwords,PorterStemmer)\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process ApplyLocalMatching\n",
-            "[main] INFO org.terrier.structures.FSADocumentIndex - Document index requires 44.6 KiB remaining heap is 7.9 GiB\n",
-            "[Thread-6] INFO org.terrier.utility.TerrierTimer - Loading document document lengths 5% done. Estimated finished in 0m00s\n",
-            "[main] INFO org.terrier.querying.LocalManager - mathemat { req=null, w=1.0, stats=null, models=[org.terrier.matching.models.DPH@2f08c4b] tags=[firstmatchscore]} \n",
-            "[main] INFO org.terrier.matching.PostingListManager - Query 2 with 1 terms has 1 posting lists\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process PostFilterProcess\n",
-            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta reading lookup file into memory\n",
-            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta reading reverse map for key docno directly from disk\n",
-            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta loading data file into memory\n",
-            "[main] INFO org.terrier.querying.LocalManager - running process SimpleDecorateProcess\n",
-            "[main] INFO org.terrier.querying.LocalManager - Finished executing query 2 in 89ms - 152 results retrieved\n"
-          ]
-        },
         {
           "data": {
             "text/html": [
@@ -1019,7 +873,7 @@
               "[152 rows x 6 columns]"
             ]
           },
-          "execution_count": 15,
+          "execution_count": 14,
           "metadata": {},
           "output_type": "execute_result"
         }

--- a/examples/notebooks/indexing.ipynb
+++ b/examples/notebooks/indexing.ipynb
@@ -26,7 +26,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -36,58 +36,7 @@
         "id": "JWLqWXBHeBRc",
         "outputId": "04d8b4fa-7e60-4ccc-ad6b-3b95f0445437"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Collecting python-terrier\n",
-            "  Cloning https://github.com/terrier-org/pyterrier.git to /tmp/pip-install-1xbb7l2t/python-terrier\n",
-            "  Running command git clone -q https://github.com/terrier-org/pyterrier.git /tmp/pip-install-1xbb7l2t/python-terrier\n",
-            "Collecting pyjnius~=1.3.0\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/d8/50/098cb5fb76fb7c7d99d403226a2a63dcbfb5c129b71b7d0f5200b05de1f0/pyjnius-1.3.0-cp36-cp36m-manylinux2010_x86_64.whl (1.1MB)\n",
-            "\u001b[K     |████████████████████████████████| 1.1MB 2.8MB/s \n",
-            "\u001b[?25hRequirement already satisfied, skipping upgrade: numpy in /usr/local/lib/python3.6/dist-packages (from python-terrier) (1.18.4)\n",
-            "Requirement already satisfied, skipping upgrade: pandas in /usr/local/lib/python3.6/dist-packages (from python-terrier) (1.0.4)\n",
-            "Collecting wget\n",
-            "  Downloading https://files.pythonhosted.org/packages/47/6a/62e288da7bcda82b935ff0c6cfe542970f04e29c756b0e147251b2fb251f/wget-3.2.zip\n",
-            "Collecting pytrec_eval\n",
-            "  Downloading https://files.pythonhosted.org/packages/36/0a/5809ba805e62c98f81e19d6007132712945c78e7612c11f61bac76a25ba3/pytrec_eval-0.4.tar.gz\n",
-            "Requirement already satisfied, skipping upgrade: tqdm in /usr/local/lib/python3.6/dist-packages (from python-terrier) (4.41.1)\n",
-            "Collecting matchpy\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/47/95/d265b944ce391bb2fa9982d7506bbb197bb55c5088ea74448a5ffcaeefab/matchpy-0.5.1-py3-none-any.whl (67kB)\n",
-            "\u001b[K     |████████████████████████████████| 71kB 7.1MB/s \n",
-            "\u001b[?25hCollecting deprecation\n",
-            "  Downloading https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl\n",
-            "Requirement already satisfied, skipping upgrade: cython in /usr/local/lib/python3.6/dist-packages (from pyjnius~=1.3.0->python-terrier) (0.29.19)\n",
-            "Requirement already satisfied, skipping upgrade: six>=1.7.0 in /usr/local/lib/python3.6/dist-packages (from pyjnius~=1.3.0->python-terrier) (1.12.0)\n",
-            "Requirement already satisfied, skipping upgrade: python-dateutil>=2.6.1 in /usr/local/lib/python3.6/dist-packages (from pandas->python-terrier) (2.8.1)\n",
-            "Requirement already satisfied, skipping upgrade: pytz>=2017.2 in /usr/local/lib/python3.6/dist-packages (from pandas->python-terrier) (2018.9)\n",
-            "Collecting multiset<3.0,>=2.0\n",
-            "  Downloading https://files.pythonhosted.org/packages/a8/12/813a649f5bc9801865dc6cda95b8f169f784d996322db192907ebe399064/multiset-2.1.1-py2.py3-none-any.whl\n",
-            "Collecting hopcroftkarp<2.0,>=1.2\n",
-            "  Downloading https://files.pythonhosted.org/packages/6b/56/7b03eba3c43008c490c9d52e69ea5334b65955f66836eb4f1962f3b0d421/hopcroftkarp-1.2.5.tar.gz\n",
-            "Requirement already satisfied, skipping upgrade: packaging in /usr/local/lib/python3.6/dist-packages (from deprecation->python-terrier) (20.4)\n",
-            "Requirement already satisfied, skipping upgrade: pyparsing>=2.0.2 in /usr/local/lib/python3.6/dist-packages (from packaging->deprecation->python-terrier) (2.4.7)\n",
-            "Building wheels for collected packages: python-terrier, wget, pytrec-eval, hopcroftkarp\n",
-            "  Building wheel for python-terrier (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for python-terrier: filename=python_terrier-0.1.3-cp36-none-any.whl size=29566 sha256=6929651f224399255efa6ea2d368e9a434ef43362b829d8c019f228cf1f1d848\n",
-            "  Stored in directory: /tmp/pip-ephem-wheel-cache-jg2en2vu/wheels/cc/bb/69/836d846a92c787b35ca6478119c0033762ab2b95d866eeb288\n",
-            "  Building wheel for wget (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for wget: filename=wget-3.2-cp36-none-any.whl size=9682 sha256=b618609a13f95e8bf46899190330a98c380e95e999f4bbfabac784f9d9064535\n",
-            "  Stored in directory: /root/.cache/pip/wheels/40/15/30/7d8f7cea2902b4db79e3fea550d7d7b85ecb27ef992b618f3f\n",
-            "  Building wheel for pytrec-eval (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for pytrec-eval: filename=pytrec_eval-0.4-cp36-cp36m-linux_x86_64.whl size=273904 sha256=c6cdd7a5a3fb03bc3e83782ffdbe0b89a297df7d251d92f4e3459f9857d5a6d3\n",
-            "  Stored in directory: /root/.cache/pip/wheels/58/30/73/8858a1b6e5e2674e2ea85c9904949c06addcf6fd34d59b5ea6\n",
-            "  Building wheel for hopcroftkarp (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for hopcroftkarp: filename=hopcroftkarp-1.2.5-py2.py3-none-any.whl size=18092 sha256=3422723d4dacff52d79490bf029f0f489472a2dd657a4e44868a9aef5f6733c3\n",
-            "  Stored in directory: /root/.cache/pip/wheels/2b/e1/c9/1993c7f7f114b7d3fb2d3e895e02157a7ebf554861e9e54e01\n",
-            "Successfully built python-terrier wget pytrec-eval hopcroftkarp\n",
-            "Installing collected packages: pyjnius, wget, pytrec-eval, multiset, hopcroftkarp, matchpy, deprecation, python-terrier\n",
-            "Successfully installed deprecation-2.1.0 hopcroftkarp-1.2.5 matchpy-0.5.1 multiset-2.1.1 pyjnius-1.3.0 python-terrier-0.1.3 pytrec-eval-0.4 wget-3.2\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "%pip install -q python-terrier"
       ]
@@ -101,12 +50,14 @@
       "source": [
         "## Initialisation\n",
         "\n",
-        "PyTerrier needs Java 11 installed. If it cannot find your Java installation, you can set the `JAVA_HOME` environment variable."
+        "PyTerrier needs Java 11 installed. If it cannot find your Java installation, you can set the `JAVA_HOME` environment variable.\n",
+        "\n",
+        "(Since version 0.11, `pt.init()` is no longer required, but many of the options are available under `pt.java.` and `pt.terrier` packages.)"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 1,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -116,22 +67,9 @@
         "id": "k3ltUZ8PgWmz",
         "outputId": "647fe3a9-6171-4ad0-8537-17c90aa03943"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "terrier-assemblies 5.2  jar-with-dependencies not found, downloading to /root/.pyterrier...\n",
-            "Done\n",
-            "terrier-python-helper 0.0.2  jar not found, downloading to /root/.pyterrier...\n",
-            "Done\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
-        "import pyterrier as pt\n",
-        "if not pt.started():\n",
-        "  pt.init()"
+        "import pyterrier as pt"
       ]
     },
     {
@@ -148,7 +86,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 2,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -163,19 +101,19 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Files in vaswani corpus: ['/root/.pyterrier/corpora/vaswani/corpus/doc-text.trec'] \n"
+            "Files in vaswani corpus: ['/Users/craigm/.pyterrier/corpora/vaswani/corpus/doc-text.trec'] \n"
           ]
         }
       ],
       "source": [
-        "dataset = pt.datasets.get_dataset(\"vaswani\")\n",
+        "dataset = pt.get_dataset(\"vaswani\")\n",
         "\n",
         "print(\"Files in vaswani corpus: %s \" % dataset.get_corpus())"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 3,
       "metadata": {
         "colab": {},
         "colab_type": "code",
@@ -199,7 +137,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 4,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -211,11 +149,15 @@
       },
       "outputs": [
         {
-          "name": "stdout",
+          "name": "stderr",
           "output_type": "stream",
           "text": [
-            "IndexingType.CLASSIC\n",
-            "IndexingType.CLASSIC\n"
+            "SLF4J: Class path contains multiple SLF4J bindings.\n",
+            "SLF4J: Found binding in [jar:file:/Users/craigm/opt/anaconda3/lib/python3.9/site-packages/pyserini/resources/jars/anserini-0.22.0-fatjar.jar!/org/slf4j/impl/StaticLoggerBinder.class]\n",
+            "SLF4J: Found binding in [jar:file:/Users/craigm/.m2/repository/org/terrier/terrier-assemblies/5.9/terrier-assemblies-5.9-jar-with-dependencies.jar!/org/slf4j/impl/StaticLoggerBinder.class]\n",
+            "SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.\n",
+            "SLF4J: Actual binding is of type [org.slf4j.impl.SimpleLoggerFactory]\n",
+            "Java started (triggered by TerrierIndexer.__init__) and loaded: pyterrier.java, pyterrier.anserini.java [version=0.22.0 (from pyserini package)], pyterrier.terrier.java [version=5.9 (build: craigm 2024-05-02 17:40), helper_version=0.0.8 prf_version=-SNAPSHOT]\n"
           ]
         }
       ],
@@ -236,13 +178,44 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 5,
       "metadata": {
         "colab": {},
         "colab_type": "code",
         "id": "l3C3NLUwQq0p"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[main] INFO org.terrier.indexing.MultiDocumentFileCollection - TRECCollection 0% processing /Users/craigm/.pyterrier/corpora/vaswani/corpus/doc-text.trec\n",
+            "[main] INFO org.terrier.structures.indexing.Indexer - creating the data structures data_1\n",
+            "[main] INFO org.terrier.structures.indexing.LexiconBuilder - LexiconBuilder active - flushing every 100000 documents, or when memory threshold hit\n",
+            "[main] INFO org.terrier.structures.indexing.BaseMetaIndexBuilder - ZstdMetaIndexBuilder meta achieved compression ratio 3.0456963 (> 1 is better)\n",
+            "[main] INFO org.terrier.structures.indexing.LexiconBuilder - 1 lexicons to merge\n",
+            "[main] INFO org.terrier.structures.indexing.LexiconBuilder - Optimising structure lexicon\n",
+            "[main] INFO org.terrier.structures.indexing.FSOMapFileLexiconUtilities - Optimising lexicon with 7756 entries\n",
+            "[main] INFO org.terrier.structures.indexing.Indexer - Started building the block inverted index...\n",
+            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - creating block inverted index\n",
+            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - BlockMemSizeLexiconScanner: lexicon scanning until approx 6.2 GiB of memory, including positions, is consumed\n",
+            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - Iteration 1 of 2 (estimated) iterations\n",
+            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - time to process part of lexicon: 0.027\n",
+            "[main] INFO org.terrier.structures.FSADocumentIndex - Document index requires 44.6 KiB remaining heap is 7.9 GiB\n",
+            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - time to traverse direct file: 0.114\n",
+            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - time to write inverted file: 0.046\n",
+            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - temporary memory used: 3.6 MiB\n",
+            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - time to perform one iteration: 0.192\n",
+            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - number of pointers processed: 224573\n",
+            "[main] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - Finished generating inverted file, rewriting lexicon\n",
+            "[main] INFO org.terrier.structures.indexing.LexiconBuilder - Optimising structure lexicon\n",
+            "[main] INFO org.terrier.structures.indexing.FSOMapFileLexiconUtilities - Optimising lexicon with 7756 entries\n",
+            "[main] INFO org.terrier.structures.indexing.Indexer - Finished building the block inverted index...\n",
+            "[main] INFO org.terrier.structures.indexing.Indexer - Time elapsed for inverted file: 0\n",
+            "[main] INFO org.terrier.structures.indexing.Indexer - Collection took 2 seconds to index (11429 documents)\n"
+          ]
+        }
+      ],
       "source": [
         "indexref = indexer.index(dataset.get_corpus())\n",
         "\n",
@@ -265,7 +238,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 6,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -282,10 +255,8 @@
               "'./index/data.properties'"
             ]
           },
-          "execution_count": 12,
-          "metadata": {
-            "tags": []
-          },
+          "execution_count": 6,
+          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -305,7 +276,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 7,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -317,14 +288,33 @@
       },
       "outputs": [
         {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[main] INFO org.terrier.structures.FSADocumentIndex - Document index requires 44.6 KiB remaining heap is 7.9 GiB\n",
+            "[Thread-2] INFO org.terrier.utility.TerrierTimer - Loading document document lengths 1% done. Estimated finished in 0m00s\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta reading lookup file into memory\n",
+            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta reading reverse map for key docno directly from disk\n",
+            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta loading data file into memory\n"
+          ]
+        },
+        {
           "name": "stdout",
           "output_type": "stream",
           "text": [
             "Number of documents: 11429\n",
             "Number of terms: 7756\n",
+            "Number of postings: 224573\n",
             "Number of fields: 0\n",
-            "Field names: []\n",
             "Number of tokens: 271581\n",
+            "Field names: []\n",
+            "Positions:   true\n",
             "\n"
           ]
         }
@@ -353,14 +343,12 @@
       "source": [
         "## Indexing a Pandas dataframe\n",
         "\n",
-        "Sometimes we have the documents that we want to index in memory. Terrier makes it easy to index standard Python data structures, particularly [Pandas dataframes](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).\n",
-        "\n",
-        "To do thise, we can use a `pt.DFIndexer()` object"
+        "Sometimes we have the documents that we want to index in memory. Terrier makes it easy to index standard Python data structures, including [Pandas dataframes](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).\n"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 8,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -370,58 +358,23 @@
         "id": "vw-4NIjlUY16",
         "outputId": "ebc0b75e-3449-4e38-c6e2-01ddd77f5de9"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "IndexingType.CLASSIC\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "import pandas as pd\n",
         "!rm -rf ./pd_index\n",
-        "pd_indexer = pt.DFIndexer(\"./pd_index\")\n",
+        "pd_indexer = pt.IterDictIndexer(\"./pd_index\")\n",
         "\n",
-        "# optionally modify properties\n",
-        "# index_properies = {\"block.indexing\":\"true\", \"invertedfile.lexiconscanner\":\"pointers\"}\n",
-        "# indexer.setProperties(**index_properies)"
+        "# optionally change how indexing occur, for instance, recording positions\n",
+        "# pd_indexer = pt.IterDictIndexer(\"./pd_index\", blocks=True)"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 11,
       "metadata": {
         "colab": {},
         "colab_type": "code",
         "id": "NNkn2SdsPzBQ"
-      },
-      "outputs": [],
-      "source": [
-        "df = pd.DataFrame({ \n",
-        "'docno':\n",
-        "['1', '2', '3'],\n",
-        "'url': \n",
-        "['url1', 'url2', 'url3'],\n",
-        "'text': \n",
-        "['He ran out of money, so he had to stop playing',\n",
-        "'The waves were crashing on the shore; it was a',\n",
-        "'The body may perhaps compensates for the loss']\n",
-        "})"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 18,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 142
-        },
-        "colab_type": "code",
-        "id": "Vn-2M9iFyW9K",
-        "outputId": "7375299a-c13d-42fc-d2cd-34aecdbbee4a"
       },
       "outputs": [
         {
@@ -480,14 +433,22 @@
               "2     3  url3   The body may perhaps compensates for the loss"
             ]
           },
-          "execution_count": 18,
-          "metadata": {
-            "tags": []
-          },
+          "execution_count": 11,
+          "metadata": {},
           "output_type": "execute_result"
         }
       ],
       "source": [
+        "df = pd.DataFrame({ \n",
+        "'docno':\n",
+        "['1', '2', '3'],\n",
+        "'url': \n",
+        "['url1', 'url2', 'url3'],\n",
+        "'text': \n",
+        "['He ran out of money, so he had to stop playing',\n",
+        "'The waves were crashing on the shore; it was a',\n",
+        "'The body may perhaps compensates for the loss']\n",
+        "})\n",
         "df"
       ]
     },
@@ -505,30 +466,43 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 12,
       "metadata": {
         "colab": {},
         "colab_type": "code",
         "id": "rBXHWO4yUJT7"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.Indexer - Indexer using 1 fields\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.Indexer - creating the data structures data_stream0_1\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - LexiconBuilder active - flushing every 100000 documents, or when memory threshold hit\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.BaseMetaIndexBuilder - ZstdMetaIndexBuilder meta achieved compression ratio 3.5882354 (> 1 is better)\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - 1 lexicons to merge\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - Optimising structure lexicon\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.FSOMapFileLexiconUtilities - Optimising lexicon with 10 entries\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.Indexer - Started building the inverted index...\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - BasicMemSizeLexiconScanner: lexicon scanning until approx 6.2 GiB of memory is consumed\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - Iteration 1 of 1 (estimated) iterations\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - Optimising structure lexicon\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - lexicon has 1 fields\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.FSOMapFileLexiconUtilities - Optimising lexicon with 10 entries\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.Indexer - Finished building the inverted index...\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.Indexer - Time elapsed for inverted file: 0\n",
+            "[ForkJoinPool-1-worker-1] INFO org.terrier.structures.indexing.Indexer - Collection took 0 seconds to index (3 documents)\n"
+          ]
+        }
+      ],
       "source": [
         "# no metadata\n",
         "# pd_indexer.index(df[\"text\"])\n",
         "\n",
         "# Add metadata fields as Pandas.Series objects, with the name of the Series object becoming the name of the meta field.\n",
-        "indexref2 = pd_indexer.index(df[\"text\"], df[\"docno\"])\n",
-        "# pd_indexer.index(df[\"text\"], df[\"docno\"], df[\"url\"])\n",
-        "\n",
-        "# Add metadata fields as lists to a keyword arguement\n",
-        "# pd_indexer.index(df[\"text\"], docno=[\"1\",\"2\",\"3\"], url=[\"url1\", \"url2\", \"url3\"])\n",
-        "\n",
-        "# Add the metadata fields with a dictionary\n",
-        "# meta_fields={\"docno\":[\"1\",\"2\",\"3\"],\"url\":[\"url1\", \"url2\", \"url3\"]}\n",
-        "# pd_indexer.index(df[\"text\"], **meta_fields)\n",
-        "\n",
-        "# Add the entire dataframe as metadata\n",
-        "# pd_indexer.index(df[\"text\"], df)"
+        "indexref2 = pd_indexer.index(df.to_dict(orient='records'))\n",
+        "# pd_indexer.index(df[\"text\"], df[\"docno\"], df[\"url\"])"
       ]
     },
     {
@@ -542,12 +516,14 @@
         "\n",
         "You may not want to load all documents into memory, particularly for large collections. Terrier can index iterable objects (e.g., generators) that yield `dict` objects.\n",
         "\n",
-        "To do thise, we can use a `pt.IterDictIndexer()` object. By default, `text` will be indexed and `docno` will be stored in the meta index. These can be configured with the `fields` and `meta` parameters, respectively."
+        "To do this, we also use `pt.IterDictIndexer()`. By default, `text` will be indexed and `docno` will be stored in the meta index. These can be configured with the `fields` and `meta` parameters, respectively.\n",
+        "\n",
+        "Indexing this corpus of 400k passages takes around 30 seconds."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 13,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -559,14 +535,56 @@
       },
       "outputs": [
         {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.Indexer - Indexer using 1 fields\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.Indexer - creating the data structures data_stream0_1\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - LexiconBuilder active - flushing every 100000 documents, or when memory threshold hit\n"
+          ]
+        },
+        {
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "processing document 0\n",
+            "processing document 0\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[ForkJoinPool-2-worker-1] WARN org.terrier.structures.indexing.Indexer - Adding an empty document to the index (730691_1) - further warnings are suppressed\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
             "processing document 100000\n",
             "processing document 200000\n",
             "processing document 300000\n",
             "processing document 400000\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.BaseMetaIndexBuilder - ZstdMetaIndexBuilder meta achieved compression ratio 2.4496965 (> 1 is better)\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - 5 lexicons to merge\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - Optimising structure lexicon\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.FSOMapFileLexiconUtilities - Optimising lexicon with 132468 entries\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.Indexer - Started building the inverted index...\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - BasicMemSizeLexiconScanner: lexicon scanning until approx 6.1 GiB of memory is consumed\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.classical.InvertedIndexBuilder - Iteration 1 of 1 (estimated) iterations\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - Optimising structure lexicon\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.LexiconBuilder - lexicon has 1 fields\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.FSOMapFileLexiconUtilities - Optimising lexicon with 132468 entries\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.Indexer - Finished building the inverted index...\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.Indexer - Time elapsed for inverted file: 2\n",
+            "[ForkJoinPool-2-worker-1] INFO org.terrier.structures.indexing.Indexer - Collection took 35 seconds to index (403666 documents)\n",
+            "[ForkJoinPool-2-worker-1] WARN org.terrier.structures.indexing.Indexer - Indexed 2224 empty documents\n"
           ]
         }
       ],
@@ -612,7 +630,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": 14,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -623,6 +641,28 @@
         "outputId": "11b3b274-2921-4663-f91b-9ef711376582"
       },
       "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[main] INFO org.terrier.querying.LocalManager - Starting to execute query 1 - mathematical\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process TerrierQLParser\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process TerrierQLToControls\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process TerrierQLToMatchingQueryTerms\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process ApplyTermPipeline(termpipelines=Stopwords,PorterStemmer)\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process ApplyLocalMatching\n",
+            "[main] INFO org.terrier.structures.FSADocumentIndex - Document index requires 44.6 KiB remaining heap is 7.9 GiB\n",
+            "[Thread-5] INFO org.terrier.utility.TerrierTimer - Loading document document lengths 3% done. Estimated finished in 0m00s\n",
+            "[main] INFO org.terrier.querying.LocalManager - mathemat { req=null, w=1.0, stats=null, models=[org.terrier.matching.models.DPH@5f3b9c57] tags=[firstmatchscore]} \n",
+            "[main] INFO org.terrier.matching.PostingListManager - Query 1 with 1 terms has 1 posting lists\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process PostFilterProcess\n",
+            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta reading lookup file into memory\n",
+            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta reading reverse map for key docno directly from disk\n",
+            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta loading data file into memory\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process SimpleDecorateProcess\n",
+            "[main] INFO org.terrier.querying.LocalManager - Finished executing query 1 in 129ms - 152 results retrieved\n"
+          ]
+        },
         {
           "data": {
             "text/html": [
@@ -656,8 +696,8 @@
               "    <tr>\n",
               "      <th>0</th>\n",
               "      <td>1</td>\n",
-              "      <td>5040</td>\n",
-              "      <td>5041</td>\n",
+              "      <td>303</td>\n",
+              "      <td>304</td>\n",
               "      <td>0</td>\n",
               "      <td>3.566201</td>\n",
               "      <td>mathematical</td>\n",
@@ -665,8 +705,8 @@
               "    <tr>\n",
               "      <th>1</th>\n",
               "      <td>1</td>\n",
-              "      <td>303</td>\n",
-              "      <td>304</td>\n",
+              "      <td>2444</td>\n",
+              "      <td>2445</td>\n",
               "      <td>1</td>\n",
               "      <td>3.566201</td>\n",
               "      <td>mathematical</td>\n",
@@ -683,8 +723,8 @@
               "    <tr>\n",
               "      <th>3</th>\n",
               "      <td>1</td>\n",
-              "      <td>2444</td>\n",
-              "      <td>2445</td>\n",
+              "      <td>5040</td>\n",
+              "      <td>5041</td>\n",
               "      <td>3</td>\n",
               "      <td>3.566201</td>\n",
               "      <td>mathematical</td>\n",
@@ -692,8 +732,8 @@
               "    <tr>\n",
               "      <th>4</th>\n",
               "      <td>1</td>\n",
-              "      <td>5011</td>\n",
-              "      <td>5012</td>\n",
+              "      <td>1169</td>\n",
+              "      <td>1170</td>\n",
               "      <td>4</td>\n",
               "      <td>3.564534</td>\n",
               "      <td>mathematical</td>\n",
@@ -759,11 +799,11 @@
             ],
             "text/plain": [
               "    qid  docid docno  rank     score         query\n",
-              "0     1   5040  5041     0  3.566201  mathematical\n",
-              "1     1    303   304     1  3.566201  mathematical\n",
+              "0     1    303   304     0  3.566201  mathematical\n",
+              "1     1   2444  2445     1  3.566201  mathematical\n",
               "2     1   3534  3535     2  3.566201  mathematical\n",
-              "3     1   2444  2445     3  3.566201  mathematical\n",
-              "4     1   5011  5012     4  3.564534  mathematical\n",
+              "3     1   5040  5041     3  3.566201  mathematical\n",
+              "4     1   1169  1170     4  3.564534  mathematical\n",
               "..   ..    ...   ...   ...       ...           ...\n",
               "147   1   7283  7284   147  2.834784  mathematical\n",
               "148   1   6714  6715   148  2.811375  mathematical\n",
@@ -774,10 +814,8 @@
               "[152 rows x 6 columns]"
             ]
           },
-          "execution_count": 21,
-          "metadata": {
-            "tags": []
-          },
+          "execution_count": 14,
+          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -797,7 +835,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": 15,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -808,6 +846,28 @@
         "outputId": "6a4e7e45-eaa4-48a0-d069-b271e3554826"
       },
       "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[main] INFO org.terrier.querying.LocalManager - Starting to execute query 2 - mathematical\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process TerrierQLParser\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process TerrierQLToControls\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process TerrierQLToMatchingQueryTerms\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process ApplyTermPipeline(termpipelines=Stopwords,PorterStemmer)\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process ApplyLocalMatching\n",
+            "[main] INFO org.terrier.structures.FSADocumentIndex - Document index requires 44.6 KiB remaining heap is 7.9 GiB\n",
+            "[Thread-6] INFO org.terrier.utility.TerrierTimer - Loading document document lengths 5% done. Estimated finished in 0m00s\n",
+            "[main] INFO org.terrier.querying.LocalManager - mathemat { req=null, w=1.0, stats=null, models=[org.terrier.matching.models.DPH@2f08c4b] tags=[firstmatchscore]} \n",
+            "[main] INFO org.terrier.matching.PostingListManager - Query 2 with 1 terms has 1 posting lists\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process PostFilterProcess\n",
+            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta reading lookup file into memory\n",
+            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta reading reverse map for key docno directly from disk\n",
+            "[main] INFO org.terrier.structures.BaseCompressingMetaIndex - Structure meta loading data file into memory\n",
+            "[main] INFO org.terrier.querying.LocalManager - running process SimpleDecorateProcess\n",
+            "[main] INFO org.terrier.querying.LocalManager - Finished executing query 2 in 89ms - 152 results retrieved\n"
+          ]
+        },
         {
           "data": {
             "text/html": [
@@ -841,8 +901,8 @@
               "    <tr>\n",
               "      <th>0</th>\n",
               "      <td>2</td>\n",
-              "      <td>5040</td>\n",
-              "      <td>5041</td>\n",
+              "      <td>303</td>\n",
+              "      <td>304</td>\n",
               "      <td>0</td>\n",
               "      <td>3.566201</td>\n",
               "      <td>mathematical</td>\n",
@@ -850,8 +910,8 @@
               "    <tr>\n",
               "      <th>1</th>\n",
               "      <td>2</td>\n",
-              "      <td>303</td>\n",
-              "      <td>304</td>\n",
+              "      <td>2444</td>\n",
+              "      <td>2445</td>\n",
               "      <td>1</td>\n",
               "      <td>3.566201</td>\n",
               "      <td>mathematical</td>\n",
@@ -868,8 +928,8 @@
               "    <tr>\n",
               "      <th>3</th>\n",
               "      <td>2</td>\n",
-              "      <td>2444</td>\n",
-              "      <td>2445</td>\n",
+              "      <td>5040</td>\n",
+              "      <td>5041</td>\n",
               "      <td>3</td>\n",
               "      <td>3.566201</td>\n",
               "      <td>mathematical</td>\n",
@@ -877,8 +937,8 @@
               "    <tr>\n",
               "      <th>4</th>\n",
               "      <td>2</td>\n",
-              "      <td>5011</td>\n",
-              "      <td>5012</td>\n",
+              "      <td>1169</td>\n",
+              "      <td>1170</td>\n",
               "      <td>4</td>\n",
               "      <td>3.564534</td>\n",
               "      <td>mathematical</td>\n",
@@ -944,11 +1004,11 @@
             ],
             "text/plain": [
               "    qid  docid docno  rank     score         query\n",
-              "0     2   5040  5041     0  3.566201  mathematical\n",
-              "1     2    303   304     1  3.566201  mathematical\n",
+              "0     2    303   304     0  3.566201  mathematical\n",
+              "1     2   2444  2445     1  3.566201  mathematical\n",
               "2     2   3534  3535     2  3.566201  mathematical\n",
-              "3     2   2444  2445     3  3.566201  mathematical\n",
-              "4     2   5011  5012     4  3.564534  mathematical\n",
+              "3     2   5040  5041     3  3.566201  mathematical\n",
+              "4     2   1169  1170     4  3.564534  mathematical\n",
               "..   ..    ...   ...   ...       ...           ...\n",
               "147   2   7283  7284   147  2.834784  mathematical\n",
               "148   2   6714  6715   148  2.811375  mathematical\n",
@@ -959,10 +1019,8 @@
               "[152 rows x 6 columns]"
             ]
           },
-          "execution_count": 20,
-          "metadata": {
-            "tags": []
-          },
+          "execution_count": 15,
+          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -979,7 +1037,7 @@
         "id": "XLcNP0XHqwQs"
       },
       "source": [
-        "Thats the end of the indexing tutorial - you can continue with other example tutorials."
+        "Thats the end of the indexing tutorial - you can continue with other example tutorials. A good next place is retrieval_and_evaluation.ipynb as well as experiment.ipynb."
       ]
     }
   ],
@@ -993,6 +1051,18 @@
     "kernelspec": {
       "display_name": "Python 3",
       "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.9.13"
     }
   },
   "nbformat": 4,

--- a/pyterrier/terrier/index.py
+++ b/pyterrier/terrier/index.py
@@ -586,13 +586,9 @@ class _BaseIterDictIndexer(TerrierIndexer, pt.Indexer):
         else:
             all_fields = {'docno'} | set(indexed_fields) | set(self.meta.keys())
 
-
-        if hasattr(it, '__len__') and len(it) == 0:
-            # we cannot validate an empty list
-            pass
-        else:
-            (first_doc,), it = more_itertools.spy(it) # peek at the first document and validate it
-            self._validate_doc_dict(first_doc)
+        first_docs, it = more_itertools.spy(it) # peek at the first document and validate it
+        if len(first_docs) > 0: # handle empty input
+            self._validate_doc_dict(first_docs[0])
 
         # important: return an iterator here, rather than make this function a generator,
         # to be sure that the validation above happens when _filter_iterable is called,

--- a/pyterrier/terrier/index.py
+++ b/pyterrier/terrier/index.py
@@ -477,6 +477,7 @@ class DFIndexUtils:
                 ),
             lengths)
 
+@deprecated(version='0.11.0', reason="use pt.terrier.IterDictIndexer().index(dataframe.to_dict(orient='records')) instead")
 class DFIndexer(TerrierIndexer):
     """
     Use this Indexer if you wish to index a pandas.Dataframe
@@ -585,8 +586,13 @@ class _BaseIterDictIndexer(TerrierIndexer, pt.Indexer):
         else:
             all_fields = {'docno'} | set(indexed_fields) | set(self.meta.keys())
 
-        (first_doc,), it = more_itertools.spy(it) # peek at the first document and validate it
-        self._validate_doc_dict(first_doc)
+
+        if hasattr(it, '__len__') and len(it) == 0:
+            # we cannot validate an empty list
+            pass
+        else:
+            (first_doc,), it = more_itertools.spy(it) # peek at the first document and validate it
+            self._validate_doc_dict(first_doc)
 
         # important: return an iterator here, rather than make this function a generator,
         # to be sure that the validation above happens when _filter_iterable is called,

--- a/tests/test_dunder.py
+++ b/tests/test_dunder.py
@@ -86,8 +86,8 @@ class TestDunder(TempDirTestCase):
                  'The body may perhaps compensates for the loss']
         })
         import pyterrier as pt
-        pd_indexer = pt.DFIndexer(self.test_dir, stopwords=pt.TerrierStopwords.none, stemmer=pt.TerrierStemmer.none)
-        indexref = pd_indexer.index(df["text"], df["docno"])
+        pd_indexer = pt.IterDictIndexer(self.test_dir, stopwords=pt.TerrierStopwords.none, stemmer=pt.TerrierStemmer.none)
+        indexref = pd_indexer.index(df.to_dict(orient='records'))
         index = pt.IndexFactory.of(indexref)
         self.assertIsNotNone(index)
         self.assertIsNotNone(index.getLexicon())

--- a/tests/test_index_op.py
+++ b/tests/test_index_op.py
@@ -111,17 +111,17 @@ class TestIndexOp(TempDirTestCase):
         ]
 
         # Create new index from pandas dataframe
-        pd_indexer = pt.DFIndexer(tempfile.mkdtemp(), blocks=True)
+        pd_indexer = pt.IterDictIndexer(tempfile.mkdtemp(), blocks=True)
         df = pd.DataFrame(documents)
         df['docno'] = df.index.astype(str)
-        indexref = pd_indexer.index(df['text'], df['docno'])
+        indexref = pd_indexer.index(df.to_dict(orient='records'))
         index1 = pt.IndexFactory.of(indexref)
 
         # Create new index from pandas dataframe
-        pd_indexer = pt.DFIndexer(tempfile.mkdtemp(), blocks=True)
+        pd_indexer = pt.IterDictIndexer(tempfile.mkdtemp(), blocks=True)
         df = pd.DataFrame(documents)
         df['docno'] = df.index.astype(str)
-        indexref = pd_indexer.index(df['text'], df['docno'])
+        indexref = pd_indexer.index(df.to_dict(orient='records'))
         index2 = pt.IndexFactory.of(indexref)
 
         # Merge indexes

--- a/tests/test_index_with_background.py
+++ b/tests/test_index_with_background.py
@@ -32,13 +32,13 @@ class TestBackground(BaseTestCase):
         import pandas as pd
         df1 = pd.DataFrame({
             'docno': ['1048'],
-            'body':
+            'text':
                 ['h  f  noise radiators in ground flashes of tropical lightning  a '+
                 'detailed analysis of h  f  noise sources in tropical ground flashes '+
                 'v  l  f  phase characteristics deduced from atmospheric waveforms']
         })
-        pd_indexer1 = pt.DFIndexer(tempfile.mkdtemp(), type=type)
-        indexref1 = pd_indexer1.index(df1["body"], df1["docno"])
+        pd_indexer1 = pt.IterDictIndexer(tempfile.mkdtemp(), type=type)
+        indexref1 = pd_indexer1.index(df1.to_dict(orient='records'))
         index1 = pt.IndexFactory.of(indexref1)
         
         has_direct1 = index1.hasIndexStructure("direct")
@@ -107,8 +107,8 @@ class TestBackground(BaseTestCase):
                  'The wave were crash on the shore; it was a',
                  'The body may perhaps compensates for the loss']
         })
-        pd_indexer1 = pt.DFIndexer(tempfile.mkdtemp(), type=type)
-        indexref1 = pd_indexer1.index(df1["text"], df1["docno"])
+        pd_indexer1 = pt.IterDictIndexer(tempfile.mkdtemp(), type=type)
+        indexref1 = pd_indexer1.index(df1.to_dict(orient='records'))
 
         df2 = pd.DataFrame({
             'docno': ['14'],
@@ -118,8 +118,8 @@ class TestBackground(BaseTestCase):
         from jnius import JavaException
         try:
 
-            pd_indexer2 = pt.DFIndexer(tempfile.mkdtemp(), type=type)
-            indexref2 = pd_indexer2.index(df2["text"], df2["docno"])
+            pd_indexer2 = pt.IterDictIndexer(tempfile.mkdtemp(), type=type)
+            indexref2 = pd_indexer2.index(df2.to_dict(orient='records'))
             
             index1 = pt.IndexFactory.of(indexref1)
             self.assertEqual(3, index1.getCollectionStatistics().getNumberOfDocuments())


### PR DESCRIPTION
WIP deprecating DFIndexer:

Problems remaining
 - [x]  update indexing.ipynb
 - [x]  fix text.scorer (may require pt.IterDictIndexer to accept memory as a target)