### PR TITLE
fix logger error

### DIFF
--- a/pyterrier/terrier/java.py
+++ b/pyterrier/terrier/java.py
@@ -36,6 +36,9 @@ def set_prf_version(version: Optional[str] = None):
 
 
 class TerrierJavaInit(pt.java.JavaInitializer):
+    def priority(self) -> int:
+        return -10 # needs to be between pt.java.core (-100) and pt.anserini (0) to avoid issues with logger configs
+
     def pre_init(self, jnius_config):
         # Make sure the terrier.default.properties file exists and is registered as an option, which avoids an annoying
         # "No etc/terrier.properties, using terrier.default.properties for bootstrap configuration." message.


### PR DESCRIPTION
**The problem:** Log level wasn't being set properly when anserini module loaded

**The reason:** Was using the version of SLF4J distributed with anserini instead of the one with pyterrier

**The solution:** Ensure the terrier jar is loaded before the anserini one by setting its priority