### PR TITLE
deprecated modules

### DIFF
--- a/pyterrier/batchretrieve.py
+++ b/pyterrier/batchretrieve.py
@@ -1,0 +1,25 @@
+"""DEPRECATED MODULE
+
+Warning: This module is deprecated and will be removed in a future version.
+
+It isn't loaded by __init__ -- it's intended to handle cases where users:
+import pyterrier.batchretrieve
+or
+from pyterrier.batchretrieve import X
+"""
+from deprecated import deprecated
+import pyterrier as pt
+
+BatchRetrieve = pt.terrier.BatchRetrieve # already has @deprecated
+FeaturesBatchRetrieve = pt.terrier.FeaturesBatchRetrieve # already has @deprecated
+BatchRetrieveBase = pt.terrier.BatchRetrieveBase # already has @deprecated
+
+@deprecated(version='0.11.0', reason="use pt.terrier.TextScorer() instead")
+class TextScorer(pt.terrier.TextScorer):
+    @staticmethod
+    @deprecated(version='0.11.0', reason="use pt.terrier.TextScorer.from_dataset() instead")
+    def from_dataset(*args, **kwargs):
+        return pt.terrier.TextScorer.from_dataset(*args, **kwargs)
+
+
+_from_dataset = deprecated(version='0.11.0', reason="use pt.datasets.transformer_from_dataset() instead")(pt.datasets.transformer_from_dataset)

--- a/pyterrier/index.py
+++ b/pyterrier/index.py
@@ -1,0 +1,37 @@
+"""DEPRECATED MODULE
+
+Warning: This module is deprecated and will be removed in a future version.
+
+It isn't loaded by __init__ -- it's intended to handle cases where users:
+import pyterrier.index
+or
+from pyterrier.index import X
+"""
+
+from deprecated import deprecated
+from enum import Enum
+import pyterrier as pt
+
+@deprecated(version='0.11.0', reason="use pt.terrier.IterDictIndexer() instead")
+class IterDictIndexer(pt.terrier.IterDictIndexer):
+    pass
+
+@deprecated(version='0.11.0', reason="use pt.terrier.DFIndexer() instead")
+class DFIndexer(pt.terrier.DFIndexer):
+    pass
+
+@deprecated(version='0.11.0', reason="use pt.terrier.TRECCollectionIndexer() instead")
+class TRECCollectionIndexer(pt.terrier.DFIndexer):
+    pass
+
+@deprecated(version='0.11.0', reason="use pt.terrier.FilesIndexer() instead")
+class FilesIndexer(pt.terrier.DFIndexer):
+    pass
+
+# Enumerations are tricky since we can't subclass them :(. Just duplicate while deprecated
+
+@deprecated(version='0.11.0', reason="use pt.terrier.IndexingType() instead")
+class IndexingType(Enum):
+    CLASSIC = 1
+    SINGLEPASS = 2
+    MEMORY = 3

--- a/pyterrier/terrier/__init__.py
+++ b/pyterrier/terrier/__init__.py
@@ -2,7 +2,7 @@
 from pyterrier.terrier import java
 from pyterrier.terrier._text_loader import TerrierTextLoader, terrier_text_loader
 from pyterrier.terrier.java import configure, set_version, set_helper_version, extend_classpath, J, set_property, set_properties, run, version, check_version, check_helper_version
-from pyterrier.terrier.retriever import Retriever, FeaturesRetriever, TextScorer
+from pyterrier.terrier.retriever import RetrieverBase, Retriever, FeaturesRetriever, TextScorer
 from pyterrier.terrier.index_factory import IndexFactory
 from pyterrier.terrier.stemmer import TerrierStemmer
 from pyterrier.terrier.tokeniser import TerrierTokeniser
@@ -40,12 +40,17 @@ class FeaturesBatchRetrieve(FeaturesRetriever):
         return FeaturesRetriever.from_dataset(*args, **kwargs)
 
 
+@deprecated(version='0.11.0', reason="use pt.terrier.RetrieverBase() instead")
+class BatchRetrieveBase(RetrieverBase):
+    pass
+
+
 __all__ = [
     # java stuff
     'java', 'configure', 'set_version', 'set_helper_version', 'extend_classpath', 'J', 'version', 'check_version', 'check_helper_version',
 
     # retrieval
-    'Retriever', 'BatchRetrieve', 'TerrierRetrieve', 'FeaturesRetriever', 'FeaturesBatchRetrieve', 'TerrierRetrieve', 'TextScorer',
+    'BatchRetrieveBase', 'Retriever', 'RetrieverBase', 'BatchRetrieve', 'TerrierRetrieve', 'FeaturesRetriever', 'FeaturesBatchRetrieve', 'TerrierRetrieve', 'TextScorer',
 
     # indexing
     'index', 'TerrierIndexer', 'FilesIndexer', 'TRECCollectionIndexer', 'DFIndexer', 'DFIndexUtils', 'IterDictIndexer', 'IndexingType', 'treccollection2textgen',


### PR DESCRIPTION
to handle existing usage of the following without breaking

```python
import pyterrier.batchretrieve
from pyterrier.batchretrieve import X
import pyterrier.index
from pyterrier.index import X
```

The functions/classes included in each module were mined using a search over public GitHub, plus anything else that seemed likely to be used.