### PR TITLE
support verbose=True on by_query iter

### DIFF
--- a/pyterrier/apply.py
+++ b/pyterrier/apply.py
@@ -206,7 +206,7 @@ def generic(fn : Union[Callable[[pd.DataFrame], pd.DataFrame], Callable[[pt.mode
         return ApplyGenericIterTransformer(fn, *args, batch_size=batch_size, **kwargs)
     return ApplyGenericTransformer(fn, *args, batch_size=batch_size, **kwargs)
 
-def by_query(fn : Union[Callable[[pd.DataFrame], pd.DataFrame], Callable[[pt.model.IterDict], pt.model.IterDict]], *args, batch_size=None, iter=False, **kwargs) -> pt.Transformer:
+def by_query(fn : Union[Callable[[pd.DataFrame], pd.DataFrame], Callable[[pt.model.IterDict], pt.model.IterDict]], *args, batch_size=None, iter=False, verbose=False, **kwargs) -> pt.Transformer:
     """
         As `pt.apply.generic()` except that fn receives a dataframe (or iter-dict) for one query at at time, rather than all results at once.
         If batch_size is set, fn will receive no more than batch_size documents for any query. The verbose kwargs controls whether
@@ -221,8 +221,8 @@ def by_query(fn : Union[Callable[[pd.DataFrame], pd.DataFrame], Callable[[pt.mod
     if iter:
         if kwargs.get("add_ranks", False):
             raise ValueError("add_ranks=True not supported with iter=True")
-        return ApplyIterForEachQuery(fn, *args, batch_size=batch_size, **kwargs)
-    return ApplyForEachQuery(fn, *args, batch_size=batch_size, **kwargs)
+        return ApplyIterForEachQuery(fn, *args, batch_size=batch_size, verbose=verbose, **kwargs)
+    return ApplyForEachQuery(fn, *args, batch_size=batch_size, verbose=verbose, **kwargs)
 
 class _apply:
 

--- a/pyterrier/apply_base.py
+++ b/pyterrier/apply_base.py
@@ -198,8 +198,7 @@ class ApplyIterForEachQuery(pt.Transformer):
         return "pt.apply.by_query()"
 
     def transform_iter(self, inp: pt.model.IterDict) -> pt.model.IterDict:
-        import collections.abc
-        if self.verbose and isinstance(inp, collections.abc.Sized):
+        if self.verbose:
             inp = pt.tqdm(inp, desc="pt.apply.by_query()")
         if self.batch_size is not None:
             for _, group in itertools.groupby(inp, key=lambda row: row['qid']):

--- a/pyterrier/apply_base.py
+++ b/pyterrier/apply_base.py
@@ -181,6 +181,7 @@ class ApplyIterForEachQuery(pt.Transformer):
     def __init__(self,
         fn: Callable[[pt.model.IterDict], pt.model.IterDict],
         *,
+        verbose=False,
         batch_size=None):
         """
         Instantiates a ApplyIterForEachQuery.
@@ -190,12 +191,16 @@ class ApplyIterForEachQuery(pt.Transformer):
             batch_size: The number of results per query to process at once. If None, processes in one batch per query.
         """
         self.fn = fn
+        self.verbose = verbose
         self.batch_size = batch_size
 
     def __repr__(self):
         return "pt.apply.by_query()"
 
     def transform_iter(self, inp: pt.model.IterDict) -> pt.model.IterDict:
+        import collections.abc
+        if self.verbose and isinstance(inp, collections.abc.Sized):
+            inp = pt.tqdm(inp, desc="pt.apply.by_query()")
         if self.batch_size is not None:
             for _, group in itertools.groupby(inp, key=lambda row: row['qid']):
                 for batch in more_itertools.ichunked(group, self.batch_size):


### PR DESCRIPTION
We'd like to be able to have `verbose=True` on `@pta.transform.by_query()` decorator, i.e. `pt.apply.by_query(, iter=True, verbose=True)`

This patch is a possible version to allow that without materialising inp.


Here's the output of a test case:
```
>>> pt.apply.by_query(lambda iter: (i for i in iter), iter=True, verbose=True)([{'qid': 'q1'}, {'qid': 'q2'}])
pt.apply.by_query(): 100%|███████████████| 2/2 [00:00<00:00, 27060.03it/s]
[{'qid': 'q1'}, {'qid': 'q2'}]
```

