### PR TITLE
fix index hooks in FilesIndexer and DFIndexer (which implement custom stopword support)

### DIFF
--- a/pyterrier/terrier/index.py
+++ b/pyterrier/terrier/index.py
@@ -522,12 +522,20 @@ class DFIndexer(TerrierIndexer):
         self.index_called = True
         collectionIterator = None
 
-        for hook in self.cleanup_hooks:
-            hook(self, index.getIndex())
-
+        indexref = None
         if self.type is IndexingType.MEMORY:
-            return index.getIndex().getIndexRef()
-        return pt.terrier.J.IndexRef.of(self.index_dir + "/data.properties")
+            index = index.getIndex()
+            indexref = index.getIndexRef()
+        else:
+            indexref = pt.terrier.J.IndexRef.of(self.index_dir + "/data.properties")
+            if len(self.cleanup_hooks) > 0:
+                sindex = pt.terrier.J.Index
+                sindex.setIndexLoadingProfileAsRetrieval(False)
+                index = pt.terrier.IndexFactory.of(indexref)
+                for hook in self.cleanup_hooks:
+                    hook(self, index)
+                sindex.setIndexLoadingProfileAsRetrieval(True)
+        return indexref
 
 
 class _BaseIterDictIndexer(TerrierIndexer, pt.Indexer):
@@ -940,9 +948,17 @@ class FilesIndexer(TerrierIndexer):
         lastdoc = None
         self.index_called = True
 
-        for hook in self.cleanup_hooks:
-            hook(self, index.getIndex())
-
+        indexref = None
         if self.type is IndexingType.MEMORY:
-            return index.getIndex().getIndexRef()
-        return pt.terrier.J.IndexRef.of(self.index_dir + "/data.properties")
+            index = index.getIndex()
+            indexref = index.getIndexRef()
+        else:
+            indexref = pt.terrier.J.IndexRef.of(self.index_dir + "/data.properties")
+            if len(self.cleanup_hooks) > 0:
+                sindex = pt.terrier.J.Index
+                sindex.setIndexLoadingProfileAsRetrieval(False)
+                index = pt.terrier.IndexFactory.of(indexref)
+                for hook in self.cleanup_hooks:
+                    hook(self, index)
+                sindex.setIndexLoadingProfileAsRetrieval(True)
+        return indexref

--- a/tests/test_dfindex.py
+++ b/tests/test_dfindex.py
@@ -125,6 +125,16 @@ class TestDFIndexer(TempDirTestCase):
         # this should pass - it picks up the metadata name from the series name
         ref = pt.DFIndexer(self.test_dir).index(df_docids["body"], df_docnos['docno'])
 
+    def test_stopwords(self):
+        import pandas as pd
+        df = pd.DataFrame([{'docno': 'd1', 'text' : 'greatest hits'}])
+        indexer = pt.DFIndexer(self.test_dir, stopwords=['hits'])
+        indexref = indexer.index(df["text"], df["docno"])
+        index = pt.IndexFactory.of(indexref)
+        self.assertIsNotNone(index)
+        self.assertEqual(1, index.getCollectionStatistics().getNumberOfDocuments())
+        self.assertTrue("hits" not in index.getLexicon())
+    
     def test_createindex1_two_metadata(self):
         from pyterrier.terrier.index import IndexingType
         self._make_check_index(1, IndexingType.CLASSIC, include_urls=True)

--- a/tests/test_files_indexer.py
+++ b/tests/test_files_indexer.py
@@ -15,6 +15,14 @@ class TestFilesIndexer(TempDirTestCase):
         index = pt.IndexFactory.of(indexref)
         self.assertEqual(2, index.getCollectionStatistics().getNumberOfDocuments())
 
+    def test_2_docs_custom__stops(self):
+        files = pt.io.find_files(os.path.join(self.here, "fixtures", "sample_docs"))
+        indexer = pt.FilesIndexer(self.test_dir, stopwords=['empty'])
+        indexref = indexer.index(files)
+        index = pt.IndexFactory.of(indexref)
+        self.assertEqual(2, index.getCollectionStatistics().getNumberOfDocuments())
+        self.assertFalse("empty" in index.getLexicon())
+
     def test_2_docs_title_body_meta(self):
         sample_dir = os.path.join(self.here, "fixtures", "sample_docs")
         files = pt.io.find_files(sample_dir)


### PR DESCRIPTION
In #538, @AgustinNormand noted a problem with custom stopwords for the FilesIndexer. The same problem exists in the DFIndexer.