### PR TITLE
migrate push_queries

### DIFF
--- a/pyterrier/apply_base.py
+++ b/pyterrier/apply_base.py
@@ -383,7 +383,7 @@ class ApplyQueryTransformer(pt.Transformer):
     def transform(self, inp: pd.DataFrame) -> pd.DataFrame:    
         if "query" in inp.columns:
             # we only push if a query already exists
-            outputRes = pt.model.push_queries(inp.copy(), inplace=True, keep_original=True)
+            outputRes = pt.model.push_queries(inp, keep_original=True)
         else:
             outputRes = inp.copy()
         try:

--- a/pyterrier/model.py
+++ b/pyterrier/model.py
@@ -2,7 +2,7 @@ import math
 import itertools
 import numpy as np
 import pandas as pd
-from typing import Any, Dict, Iterable, List, Sequence, Optional
+from typing import Any, Dict, Iterable, List, Sequence, Optional, Union, Tuple
 
 IterDictRecord = Dict[str, Any]
 IterDict = Iterable[IterDictRecord]
@@ -85,6 +85,112 @@ def query_columns(df : pd.DataFrame, qid=True) -> Sequence[str]:
     return rtr
 
 
+def push_columns(
+    df: pd.DataFrame,
+    *,
+    keep_original: bool = False,
+    inplace: bool = False,
+    base_column: str = "query",
+) -> pd.DataFrame:
+    """
+    Changes a dataframe such that the selected column becomes "<column>_0", and any
+    "<column>_0" columns becomes "<column>_1" etc.
+
+    Arguments:
+        df: Dataframe with a "<column>" column
+        keep_original: if True, the <column> column is also left unchanged. Useful for client code.
+            Defaults to False.
+        inplace: if False, a copy of the dataframe is returned. If True, changes are made to the
+            supplied dataframe. Defaults to False.
+    """
+    cols = set(df.columns)
+    if base_column not in cols:
+        raise KeyError(f"Expected a {base_column} column, but found {list(cols)}")
+    if not inplace:
+        df = df.copy()
+    prev_col = base_column
+    rename_cols = {}
+    for query_idx in itertools.count():
+        next_col = f"{base_column}_{query_idx}"
+        if prev_col in cols:
+            rename_cols[prev_col] = next_col
+            prev_col = next_col
+        else:
+            break
+    # apply renaming in-place or on the copy
+    df.rename(columns=rename_cols, inplace=True)
+    if keep_original:
+        df[base_column] = df[f"{base_column}_0"]
+    return df
+
+
+def push_columns_dict(
+    inp: Union[Iterable[dict], dict],
+    keep_original: bool = False,
+    base_column: str = "query",
+) -> Union[Iterable[dict], dict]:
+    def per_element(i: dict):
+        cols = i.keys()
+        if base_column not in cols:
+            raise KeyError(f"Expected a {base_column} column, but found {list(cols)}")
+        prev_col = base_column
+        rename_cols = {}
+        for query_idx in itertools.count():
+            next_col = f"{base_column}_{query_idx}"
+            if prev_col in cols:
+                rename_cols[prev_col] = next_col
+                prev_col = next_col
+            else:
+                break
+
+        renamed = {}
+        for k, v in i.items():
+            if k in rename_cols:
+                renamed[rename_cols[k]] = v
+            else:
+                renamed[k] = v
+
+        if keep_original:
+            renamed[base_column] = renamed[f"{base_column}_0"]
+
+        return renamed
+
+    if isinstance(inp, dict):
+        return per_element(inp)
+    return [*map(per_element, inp)]
+
+
+def find_maximum_push(inp: pd.DataFrame, base_column: str = "query") -> Tuple[str, int]:
+    columns = inp.columns
+    maxcol = None
+    maxval = -1
+    for col in columns:
+        if col.startswith(f"{base_column}_"):
+            val = int(col.split("_")[1])
+            if val > maxval:
+                maxval = val
+                maxcol = col
+    return maxcol, maxval
+
+
+def find_maximum_push_dict(inp: Union[Iterable[dict], dict], base_column: str = "query") -> Tuple[str, int]:
+    def per_element(i: dict):
+        cols = i.keys()
+        maxcol = None
+        maxval = -1
+        for col in cols:
+            if col.startswith(f"{base_column}_"):
+                val = int(col.split("_")[1])
+                if val > maxval:
+                    maxval = val
+                    maxcol = col
+        return maxcol, maxval
+
+    if isinstance(inp, dict):
+        return per_element(inp)
+    return map(per_element, inp)
+
+
 def push_queries(df: pd.DataFrame, *, keep_original: bool = False, inplace: bool = False) -> pd.DataFrame:
     """
         Changes a dataframe such that the "query" column becomes "query_0", and any
@@ -97,46 +203,35 @@ def push_queries(df: pd.DataFrame, *, keep_original: bool = False, inplace: bool
             inplace: if False, a copy of the dataframe is returned. If True, changes are made to the
                 supplied dataframe. Defaults to False. 
     """
-    cols = set(df.columns)
-    if "query" not in cols:
-        raise KeyError(f"Expected a query column, but found {list(cols)}")
-    if not inplace:
-        df = df.copy()
-    prev_col = 'query'
-    rename_cols = {}
-    for query_idx in itertools.count():
-        next_col = f'query_{query_idx}'
-        if prev_col in cols:
-            rename_cols[prev_col] = next_col # map e.g., query_0 to be renamed to query_1
-            prev_col = next_col
-        else:
-             break
-    df = df.rename(columns=rename_cols)
-    if keep_original:
-        df['query'] = df["query_0"]
-    return df
+    assert not inplace, "push_queries no longer supports inplace"
+    return push_columns(df, keep_original=keep_original, inplace=inplace, base_column="query")
 
 
 def push_queries_dict(inp: IterDictRecord, *, keep_original: bool = False, inplace: bool = False) -> IterDictRecord:
     """
     Works like ``push_queries`` but over a dict instead of a dataframe.
     """
-    if "query" not in inp:
-        raise KeyError(f"Expected a query column, but found {list(inp.keys())}")
-    if not inplace:
-        inp = inp.copy()
-    prev_col = 'query'
+    assert not inplace, "push_queries_dict does not support inplace"
+    return push_columns_dict(inp, keep_original=keep_original, base_column="query")
+
+
+def pop_columns(df: pd.DataFrame, *, base_column="query") -> pd.DataFrame:
+    cols = set(df.columns)
+    if base_column + "_0" not in cols:
+        raise KeyError(f"Expected a {base_column}_0 column, but found {list(cols)}")
+    df = df.copy()
+    df.drop(columns=[base_column], inplace=True)
+    prev_col = base_column
+    rename_cols = {}
     for query_idx in itertools.count():
-        next_col = f'query_{query_idx}'
-        if prev_col in inp:
-            inp[next_col] = inp.pop(prev_col) # assign e.g., query_1 to query_0
+        next_col = f'{base_column}_{query_idx}'
+        if next_col in cols:
+            rename_cols[next_col] = prev_col # map e.g., query_1 to be renamed to query_0
             prev_col = next_col
         else:
              break
-    if keep_original:
-        inp['query'] = inp['query_0']
-    return inp
-
+    df = df.rename(columns=rename_cols)
+    return df
 
 def pop_queries(df: pd.DataFrame, *, inplace: bool = False) -> pd.DataFrame:
     """
@@ -149,24 +244,8 @@ def pop_queries(df: pd.DataFrame, *, inplace: bool = False) -> pd.DataFrame:
             inplace: if False, a copy of the dataframe is returned. If True, changes are made to the
                 supplied dataframe. Defaults to False. 
     """
-    cols = set(df.columns)
-    if "query_0" not in cols:
-        raise KeyError(f"Expected a query_0 column, but found {list(cols)}")
-    if not inplace:
-        df = df.copy()
-    df.drop(columns=["query"], inplace=True)
-    prev_col = 'query'
-    rename_cols = {}
-    for query_idx in itertools.count():
-        next_col = f'query_{query_idx}'
-        if next_col in cols:
-            rename_cols[next_col] = prev_col # map e.g., query_1 to be renamed to query_0
-            prev_col = next_col
-        else:
-             break
-    df = df.rename(columns=rename_cols)
-    return df
-
+    assert not inplace
+    return pop_columns(df, base_column="query")
 
 def ranked_documents_to_queries(topics_and_res : pd.DataFrame):
     return topics_and_res[query_columns(topics_and_res, qid=True)].groupby(["qid"]).first().reset_index()

--- a/pyterrier/terrier/rewrite.py
+++ b/pyterrier/terrier/rewrite.py
@@ -144,7 +144,7 @@ class SDM(pt.Transformer):
             results.append([qid, new_query])
         new_queries = pd.DataFrame(results, columns=["qid", "query"])
         # restore any other columns, e.g. put back docs if we are re-ranking
-        return new_queries.merge(pt.model.push_queries(topics_and_res, inplace=True) , on="qid")
+        return new_queries.merge(pt.model.push_queries(topics_and_res) , on="qid")
 
 class SequentialDependence(SDM):
     '''
@@ -310,7 +310,7 @@ class QueryExpansion(pt.Transformer):
             new_query = new_query[:-1]
             results.append([qid, new_query])
         new_queries = pd.DataFrame(results, columns=["qid", "query"])
-        return pt.model.push_queries(queries, inplace=True).merge(new_queries, on="qid")
+        return pt.model.push_queries(queries).merge(new_queries, on="qid")
 
 class DFRQueryExpansion(QueryExpansion):
 


### PR DESCRIPTION
in https://github.com/terrierteam/pyterrier_rag/pull/24, a generic form of push_queries etc was introduced by @Parry-Parry. This merges those methods upstream.

At the same time, I've removed support for inplace editing of the dataframe.