### PR TITLE
Show types of arguments in docs

### DIFF
--- a/pyterrier/apply.py
+++ b/pyterrier/apply.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Callable, Any, Dict, Union, Optional, Sequence
+from typing import Callable, Any, Dict, Union, Optional, Sequence, Literal
 import numpy.typing as npt
 import pandas as pd
 import pyterrier as pt
@@ -29,9 +29,8 @@ def query(fn : Callable[[Union[pd.Series,pt.model.IterDictRecord]], str], *args,
         The previous query formulation is saved in the "query_0" column. If a later pipeline stage is intended to resort to
         be executed on the previous query formulation, a ``pt.rewrite.reset()`` transformer can be applied.  
 
-        Arguments:
-            fn(Callable): the function to apply to each row. It must return a string containing the new query formulation.
-            verbose(bool): if set to True, a TQDM progress bar will be displayed
+        :param fn: the function to apply to each row. It must return a string containing the new query formulation.
+        :param verbose: if set to True, a TQDM progress bar will be displayed
 
         Examples::
 
@@ -69,10 +68,9 @@ def doc_score(fn : Union[Callable[[Union[pd.Series,pt.model.IterDictRecord]], fl
         The supplied function is called once for each document, and must return a float containing the new score for that document.
         Each time it is called, the function is supplied with a Panda Series representing the attributes of the query and document.
 
-        Arguments:
-            fn(Callable): the function to apply to each row
-            batch_size (int or None). How many documents to operate on at once (batch-wise). If None, operates row-wise
-            verbose(bool): if set to True, a TQDM progress bar will be displayed
+        :param fn: the function to apply to each row
+        :param batch_size: How many documents to operate on at once (batch-wise). If None, operates row-wise
+        :param verbose: if set to True, a TQDM progress bar will be displayed
 
         Example (Row-wise)::
 
@@ -105,10 +103,9 @@ def doc_features(fn : Callable[[Union[pd.Series,pt.model.IterDictRecord]], npt.N
         particular type of the input is not controlled by the implementor, so the function should be written to support both, e.g. using ``row["key"]``
         notation and not the ``row.key`` that is supported by a Series.
 
-        Arguments:
-            fn(Callable): the function to apply to each row
-            verbose(bool): if set to True, a TQDM progress bar will be displayed
-
+        :param fn: the function to apply to each row. It must return a 1D numpy array
+        :param verbose: if set to True, a TQDM progress bar will be displayed
+        
         Example::
 
             # this transformer will compute the character and number of word in each document retrieved
@@ -138,8 +135,7 @@ def indexer(fn : Callable[[pt.model.IterDict], Any], **kwargs) -> pt.Indexer:
 
         The supplied function is called once. It may optionally return something (typically a reference to the "index").
 
-        Arguments:
-            fn(Callable): the function that consumed documents.
+        :param fn: the function that consumes documents as IterDicts.
 
         Example::
 
@@ -154,13 +150,12 @@ def indexer(fn : Callable[[pt.model.IterDict], Any], **kwargs) -> pt.Indexer:
     """
     return ApplyIndexer(fn, **kwargs)
 
-def rename(columns : Dict[str,str], *args, errors='raise', **kwargs) -> pt.Transformer:
+def rename(columns : Dict[str,str], *args, errors : Literal['raise', 'ignore']='raise', **kwargs) -> pt.Transformer:
     """
         Creates a transformer that renames columns in a dataframe. 
 
-        Args:
-            columns(dict): A dictionary mapping from old column name to new column name
-            errors(str): Maps to df.rename() errors kwarg - default to 'raise', alternatively can be 'ignore'
+        :param columns: A dictionary mapping from old column name to new column name
+        :param errors: Maps to df.rename() errors kwarg - default to 'raise', alternatively can be 'ignore'
 
         Example::
             
@@ -176,11 +171,10 @@ def generic(fn : Union[Callable[[pd.DataFrame], pd.DataFrame], Callable[[pt.mode
         more queries and one or more documents). Each time it should return a new dataframe. The returned dataframe (or yielded row) 
         should abide by the general PyTerrier Data Model, for instance updating the rank column if the scores are amended.
 
-        Arguments:
-            fn(Callable): the function to apply to each result set
-            batch_size(int or None): whether to apply fn on batches of rows or all that are received
-            verbose(bool): Whether to display a progress bar over batches (only used if batch_size is set, and iter is not set).
-            iter(bool): Whether to use the iter-dict API - if-so, then ``fn`` receives an iterable, and returns an iterable. 
+        :param fn: the function to apply to each result set
+        :param batch_size: whether to apply fn on batches of rows or all that are received
+        :param verbose: Whether to display a progress bar over batches (only used if batch_size is set, and iter is not set).
+        :param iter: Whether to use the iter-dict API - if-so, then ``fn`` receives an iterable, and returns an iterable. 
 
         Example (dataframe)::
 
@@ -212,11 +206,10 @@ def by_query(fn : Union[Callable[[pd.DataFrame], pd.DataFrame], Callable[[pt.mod
         If batch_size is set, fn will receive no more than batch_size documents for any query. The verbose kwargs controls whether
         to display a progress bar over queries.  
 
-        Arguments:
-            fn(Callable): the function to apply to each row. Should return a generator
-            batch_size(int or None): whether to apply fn on batches of rows or all that are received.
-            verbose(bool): Whether to display a progress bar over batches (only used if batch_size is set, and iter is not set).
-            iter(bool): Whether to use the iter-dict API - if-so, then ``fn`` receives an iterable, and must return an iterable. 
+        :param fn: the function to apply to each row. Should return a generator
+        :param batch_size: whether to apply fn on batches of rows or all that are received.
+        :param verbose: Whether to display a progress bar over batches (only used if batch_size is set, and iter is not set).
+        :param iter: Whether to use the iter-dict API - if-so, then ``fn`` receives an iterable, and must return an iterable. 
     """
     if iter:
         if kwargs.get("add_ranks", False):

--- a/pyterrier/debug.py
+++ b/pyterrier/debug.py
@@ -7,9 +7,8 @@ def print_columns(by_query : bool = False, message : Optional[str] = None) -> Tr
     Returns a transformer that can be inserted into pipelines that can print the column names of the dataframe
     at this stage in the pipeline:
 
-    Arguments:
-     - by_query(bool): whether to display for each query. Defaults to False.
-     - message(str): whether to display a message before printing. Defaults to None, which means no message. This
+    :param by_query: whether to display for each query. Defaults to False.
+    :param message: whether to display a message before printing. Defaults to None, which means no message. This
        is useful when ``print_columns()`` is being used multiple times within a pipeline 
      
 
@@ -43,9 +42,8 @@ def print_num_rows(
     Returns a transformer that can be inserted into pipelines that can print the number of rows names of the dataframe
     at this stage in the pipeline:
 
-    Arguments:
-     - by_query(bool): whether to display for each query. Defaults to True.
-     - message(str): whether to display a message before printing. Defaults to "num_rows". This
+    :param by_query: whether to display for each query. Defaults to True.
+    :param message: whether to display a message before printing. Defaults to "num_rows". This
        is useful when ``print_columns()`` is being used multiple times within a pipeline 
      
     Example::
@@ -89,12 +87,11 @@ def print_rows(
     Returns a transformer that can be inserted into pipelines that can print some of the dataframe
     at this stage in the pipeline:
 
-    Arguments:
-     - by_query(bool): whether to display for each query. Defaults to True.
-     - jupyter(bool): Whether to use IPython's display function to display the dataframe. Defaults to True.
-     - head(int): The number of rows to display. None means all rows.
-     - columns(List[str]): Limit the columns for which data is displayed. Default of None displays all columns.
-     - message(str): whether to display a message before printing. Defaults to None, which means no message. This
+    :param by_query: whether to display for each query. Defaults to True.
+    :param jupyter: Whether to use IPython's display function to display the dataframe. Defaults to True.
+    :param head: The number of rows to display. None means all rows.
+    :param columns: Limit the columns for which data is displayed. Default of None displays all columns.
+    :param message: whether to display a message before printing. Defaults to None, which means no message. This
        is useful when ``print_rows()`` is being used multiple times within a pipeline 
 
     Example::

--- a/pyterrier/io.py
+++ b/pyterrier/io.py
@@ -162,9 +162,9 @@ def read_results(filename : str, format="trec", topics : Optional[pd.DataFrame] 
     :param format: The format of the results file: one of "trec", "letor". Default is "trec".
     :param topics: If provided, will merge the topics to merge into the results. This is helpful for providing query text. Cannot be used in conjunction with dataset argument.
     :param dataset: If provided, loads topics from the dataset (or dataset ID) and merges them into the results. This is helpful for providing query text. Cannot be used in conjunction with dataset topics.
-        **kwargs (dict): Other arguments for the internal method
+    :param kwargs: Other arguments for the internal method
 
-    :return dataframe with usual qid, docno, score columns etc
+    :return: dataframe with usual qid, docno, score columns etc
 
     Examples::
 
@@ -250,12 +250,12 @@ def write_results(res : pd.DataFrame, filename : str, format : Literal['trec', '
     :param filename: The filename of the file to be written. Compressed files are handled automatically.
     :param format: The format of the results file: one of "trec", "letor", "minimal"
     :param append: Append to an existing file. Defaults to False.
-    :param **kwargs: Other arguments for the internal method
+    :param kwargs: Other arguments for the internal method
 
     Supported Formats:
-        * "trec" -- output columns are $qid Q0 $docno $rank $score $runname, space separated
-        * "letor" -- This follows the LETOR and MSLR datasets, in that output columns are $label qid:$qid [$fid:$value]+ # docno=$docno
-        * "minimal": output columns are $qid $docno $rank, tab-separated. This is used for submissions to the MSMARCO leaderboard.
+        * "trec" -- output columns are `$qid Q0 $docno $rank $score $runname, space separated`
+        * "letor" -- This follows the LETOR and MSLR datasets, in that output columns are `$label qid:$qid [$fid:$value]+ # docno=$docno`
+        * "minimal": output columns are `$qid $docno $rank`, tab-separated. This is used for submissions to the MSMARCO leaderboard.
 
     """
     if format not in SUPPORTED_RESULTS_FORMATS:
@@ -292,9 +292,7 @@ def read_topics(filename : str, format :Literal['trec', 'trecxml', 'singleline']
     :param filename: The filename of the topics file. A URL is supported for the "trec" and "singleline" formats.
     :param format: One of "trec", "trecxml" or "singleline". Default is "trec"
 
-    Returns:
-        pandas.Dataframe with columns=['qid','query']
-        both columns have type string
+    :return: pandas.Dataframe with columns=['qid','query'], where both columns have type str.
 
     Supported Formats:
         * "trec" -- an SGML-formatted TREC topics file. Delimited by TOP tags, each having NUM and TITLE tags; DESC and NARR tags are skipped by default. Control using whitelist and blacklist kwargs

--- a/pyterrier/ltr.py
+++ b/pyterrier/ltr.py
@@ -193,8 +193,7 @@ class FastRankEstimator(Estimator):
         """
         Predicts the scores for the given topics.
 
-        Args:
-            topicsTest(DataFrame): A dataframe with the test topics.
+        :param topics_and_docs_Test: A dataframe with the test topics.
         """
         if self.model is None:
             raise ValueError("fit() must be called first")
@@ -220,8 +219,7 @@ def ablate_features(fids : FeatureList) -> Transformer:
         performing feature ablation studies, whereby a feature is removed from the pipeline
         before learning. 
 
-        Args: 
-            fids: one or a list of integers corresponding to features indices to be removed
+        :param fids: one or a list of integers corresponding to features indices to be removed
     """
     return AblateFeatures(fids)
 
@@ -231,8 +229,7 @@ def keep_features(fids : FeatureList) -> Transformer:
         performing feature ablation studies, whereby only some features are kept 
         (and other removed) from a pipeline before learning occurs. 
 
-        Args: 
-            fids: one or a list of integers corresponding to the features indice to be kept
+        :param fids: one or a list of integers corresponding to the features indice to be kept
     """
     return KeepFeatures(fids)
 
@@ -241,8 +238,7 @@ def feature_to_score(fid : int) -> Transformer:
         Applies a specified feature for ranking. Useful for evaluating which of a number of 
         pre-computed features are useful for ranking. 
 
-        Args: 
-            fid: a single feature id that should be kept
+        :param fid: a single feature id that should be kept
     """
     return pt.apply.doc_score(lambda row : row["features"][fid])
 
@@ -257,9 +253,8 @@ def apply_learned_model(learner, form : str = 'regression', **kwargs) -> Transfo
 
         xgBoost and LightGBM are also supported through the use of `type='ltr'` kwarg.
 
-        Args: 
-            learner: an sklearn-compatible estimator
-            form(str): either 'regression', 'ltr' or 'fastrank'        
+        :param learner: an sklearn-compatible estimator
+        :param form: either 'regression', 'ltr' or 'fastrank'        
     """
     if form == 'ltr':
         return LTRTransformer(learner, **kwargs)

--- a/pyterrier/pipelines.py
+++ b/pyterrier/pipelines.py
@@ -472,52 +472,50 @@ def Experiment(
     identical evaluation measures computed using the same qrels. In essence, each transformer is applied on 
     the provided set of topics. Then the named evaluation measures are computed for each system.
 
-    Args:
-        retr_systems(list): A list of transformers to evaluate. If you already have the results for one 
-            (or more) of your systems, a results dataframe can also be used here. Results produced by 
-            the transformers must have "qid", "docno", "score", "rank" columns.
-        topics: Either a path to a topics file or a pandas.Dataframe with columns=['qid', 'query']
-        qrels: Either a path to a qrels file or a pandas.Dataframe with columns=['qid','docno', 'label']   
-        eval_metrics(list): Which evaluation metrics to use. E.g. ['map']
-        names(list): List of names for each retrieval system when presenting the results.
-            Default=None. If None: Obtains the `str()` representation of each transformer as its name.
-        batch_size(int): If not None, evaluation is conducted in batches of batch_size topics. Default=None, which evaluates all topics at once. 
-            Applying a batch_size is useful if you have large numbers of topics, and/or if your pipeline requires large amounts of temporary memory
-            during a run.
-        filter_by_qrels(bool): If True, will drop topics from the topics dataframe that have qids not appearing in the qrels dataframe. 
-        filter_by_topics(bool): If True, will drop topics from the qrels dataframe that have qids not appearing in the topics dataframe. 
-        perquery(bool): If True return each metric for each query, else return mean metrics across all queries. Default=False.
-        save_dir(str): If set to the name of a directory, the results of each transformer will be saved in TREC-formatted results file, whose 
-            filename is based on the systems names (as specified by ``names`` kwarg). If the file exists and ``save_mode`` is set to "reuse", then the file
-            will be used for evaluation rather than the transformer. Default is None, such that saving and loading from files is disabled.
-        save_mode(str): Defines how existing files are used when ``save_dir`` is set. If set to "reuse", then files will be preferred
-            over transformers for evaluation. If set to "overwrite", existing files will be replaced. If set to "warn" or "error", the presence of any 
-            existing file will cause a warning or error, respectively. Default is "warn".
-        save_format(str): How are result being saved. Defaults to 'trec', which uses ``pt.io.read_results()`` and ``pt.io.write_results()`` for saving system outputs. 
-            If TREC results format is insufficient, set ``save_format=pickle``. Alternatively, a tuple of read and write function can be specified, for instance, 
-            ``save_format=(pandas.from_csv, pandas.DataFrame.to_csv)``, or even ``save_format=(pandas.from_parquet, pandas.DataFrame.to_parquet)``.
-        dataframe(bool): If True return results as a dataframe, else as a dictionary of dictionaries. Default=True.
-        baseline(int): If set to the index of an item of the retr_system list, will calculate the number of queries 
-            improved, degraded and the statistical significance (paired t-test p value) for each measure.
-            Default=None: If None, no additional columns will be added for each measure.
-        test(string): Which significance testing approach to apply. Defaults to "t". Alternatives are "wilcoxon" - not typically used for IR experiments. A Callable can also be passed - it should
-            follow the specification of `scipy.stats.ttest_rel() <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.ttest_rel.html>`_, 
-            i.e. it expect two arrays of numbers, and return an array or tuple, of which the second value will be placed in the p-value column.
-        correction(string): Whether any multiple testing correction should be applied. E.g. 'bonferroni', 'holm', 'hs' aka 'holm-sidak'. Default is None.
-            Additional columns are added denoting whether the null hypothesis can be rejected, and the corrected p value. 
-            See `statsmodels.stats.multitest.multipletests() <https://www.statsmodels.org/dev/generated/statsmodels.stats.multitest.multipletests.html#statsmodels.stats.multitest.multipletests>`_
-            for more information about available testing correction.
-        correction_alpha(float): What alpha value for multiple testing correction. Default is 0.05.
-        highlight(str): If `highlight="bold"`, highlights in bold the best measure value in each column; 
-            if `highlight="color"` or `"colour"`, then the cell with the highest metric value will have a green background.
-        round(int): How many decimal places to round each measure value to. This can also be a dictionary mapping measure name to number of decimal places.
-            Default is None, which is no rounding.
-        precompute_prefix(bool): If set to True, then pt.Experiment will look for a common prefix on all input pipelines, and execute that common prefix pipeline only once. 
-            This functionality assumes that the intermidiate results of the common prefix can fit in memory. Set to False by default.
-        verbose(bool): If True, a tqdm progress bar is shown as systems (or systems*batches if batch_size is set) are executed. Default=False.
+    :param retr_systems: A list of transformers to evaluate. If you already have the results for one 
+        (or more) of your systems, a results dataframe can also be used here. Results produced by 
+        the transformers must have "qid", "docno", "score", "rank" columns.
+    :param topics: Either a path to a topics file or a pandas.Dataframe with columns=['qid', 'query']
+    :param qrels: Either a path to a qrels file or a pandas.Dataframe with columns=['qid','docno', 'label']   
+    :param eval_metrics: Which evaluation metrics to use. E.g. ['map']
+    :param names: List of names for each retrieval system when presenting the results.
+        Default=None. If None: Obtains the `str()` representation of each transformer as its name.
+    :param batch_size: If not None, evaluation is conducted in batches of batch_size topics. Default=None, which evaluates all topics at once. 
+        Applying a batch_size is useful if you have large numbers of topics, and/or if your pipeline requires large amounts of temporary memory
+        during a run.
+    :param filter_by_qrels: If True, will drop topics from the topics dataframe that have qids not appearing in the qrels dataframe. 
+    :param filter_by_topics: If True, will drop topics from the qrels dataframe that have qids not appearing in the topics dataframe. 
+    :param perquery: If True return each metric for each query, else return mean metrics across all queries. Default=False.
+    :param save_dir: If set to the name of a directory, the results of each transformer will be saved in TREC-formatted results file, whose 
+        filename is based on the systems names (as specified by ``names`` kwarg). If the file exists and ``save_mode`` is set to "reuse", then the file
+        will be used for evaluation rather than the transformer. Default is None, such that saving and loading from files is disabled.
+    :param save_mode: Defines how existing files are used when ``save_dir`` is set. If set to "reuse", then files will be preferred
+        over transformers for evaluation. If set to "overwrite", existing files will be replaced. If set to "warn" or "error", the presence of any 
+        existing file will cause a warning or error, respectively. Default is "warn".
+    :param save_format: How are result being saved. Defaults to 'trec', which uses ``pt.io.read_results()`` and ``pt.io.write_results()`` for saving system outputs. 
+        If TREC results format is insufficient, set ``save_format=pickle``. Alternatively, a tuple of read and write function can be specified, for instance, 
+        ``save_format=(pandas.from_csv, pandas.DataFrame.to_csv)``, or even ``save_format=(pandas.from_parquet, pandas.DataFrame.to_parquet)``.
+    :param dataframe: If True return results as a dataframe, else as a dictionary of dictionaries. Default=True.
+    :param baseline: If set to the index of an item of the retr_system list, will calculate the number of queries 
+        improved, degraded and the statistical significance (paired t-test p value) for each measure.
+        Default=None: If None, no additional columns will be added for each measure.
+    :param test: Which significance testing approach to apply. Defaults to "t". Alternatives are "wilcoxon" - not typically used for IR experiments. A Callable can also be passed - it should
+        follow the specification of `scipy.stats.ttest_rel() <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.ttest_rel.html>`_, 
+        i.e. it expect two arrays of numbers, and return an array or tuple, of which the second value will be placed in the p-value column.
+    :param correction: Whether any multiple testing correction should be applied. E.g. 'bonferroni', 'holm', 'hs' aka 'holm-sidak'. Default is None.
+        Additional columns are added denoting whether the null hypothesis can be rejected, and the corrected p value. 
+        See `statsmodels.stats.multitest.multipletests() <https://www.statsmodels.org/dev/generated/statsmodels.stats.multitest.multipletests.html#statsmodels.stats.multitest.multipletests>`_
+        for more information about available testing correction.
+    :param correction_alpha: What alpha value for multiple testing correction. Default is 0.05.
+    :param highlight: If `highlight="bold"`, highlights in bold the best measure value in each column; 
+        if `highlight="color"` or `"colour"`, then the cell with the highest metric value will have a green background.
+    :param round: How many decimal places to round each measure value to. This can also be a dictionary mapping measure name to number of decimal places.
+        Default is None, which is no rounding.
+    :param precompute_prefix: If set to True, then pt.Experiment will look for a common prefix on all input pipelines, and execute that common prefix pipeline only once. 
+        This functionality assumes that the intermidiate results of the common prefix can fit in memory. Set to False by default.
+    :param verbose: If True, a tqdm progress bar is shown as systems (or systems*batches if batch_size is set) are executed. Default=False.
 
-    Returns:
-        A Dataframe with each retrieval system with each metric evaluated.
+    :return: A Dataframe with each retrieval system with each metric evaluated.
     """
     
     if not isinstance(retr_systems, list):
@@ -782,16 +780,18 @@ def _restore_state(param_state):
     for (tran, param_name, param_value) in param_state:
         tran.set_parameter(param_name, param_value)
 
-def Evaluate(res : pd.DataFrame, qrels : pd.DataFrame, metrics=['map', 'ndcg'], perquery=False) -> Dict:
+def Evaluate(res : pd.DataFrame, qrels : pd.DataFrame, metrics : MEASURES_TYPE= ['map', 'ndcg'], perquery : bool = False) -> Dict:
     """
     Evaluate a single result dataframe with the given qrels. This method may be used as an alternative to
     ``pt.Experiment()`` for getting only the evaluation measurements given a single set of existing results.
 
-    Args:
-        res: Either a dataframe with columns=['qid', 'docno', 'score'] or a dict {qid:{docno:score,},}
-        qrels: Either a dataframe with columns=['qid','docno', 'label'] or a dict {qid:{docno:label,},}
-        metrics(list): A list of strings specifying which evaluation metrics to use. Default=['map', 'ndcg']
-        perquery(bool): If true return each metric for each query, else return mean metrics. Default=False
+    The PyTerrier-way is to use ``pt.Experiment()`` to evaluate a set of transformers, but this method is useful
+    if you have a set of results already, and want to evaluate them without having to create a transformer pipeline.
+
+    :param res: Either a dataframe with columns=['qid', 'docno', 'score'] or a dict {qid:{docno:score,},}
+    :param qrels: Either a dataframe with columns=['qid','docno', 'label'] or a dict {qid:{docno:label,},}
+    :param metrics: A list of strings specifying which evaluation metrics to use. Default=['map', 'ndcg']
+    :param perquery: If true return each metric for each query, else return mean metrics. Default=False
     """
     if len(res) == 0:
         raise ValueError("No results for evaluation")
@@ -818,23 +818,21 @@ def KFoldGridSearch(
     The state of the transformers in the pipeline is restored after the KFoldGridSearch has
     been executed.
 
-    Args:
-        pipeline(Transformer): a transformer or pipeline to tune
-        params(dict): a two-level dictionary, mapping transformer to param name to a list of values
-        topics_list(List[DataFrame]): a *list* of topics dataframes to tune upon
-        qrels(DataFrame or List[DataFrame]): qrels to tune upon. A single dataframe, or a list for each fold.       
-        metric(str): name of the metric on which to determine the most effective setting. Defaults to "map".
-        batch_size(int): If not None, evaluation is conducted in batches of batch_size topics. Default=None, which evaluates all topics at once. 
-            Applying a batch_size is useful if you have large numbers of topics, and/or if your pipeline requires large amounts of temporary memory
-            during a run. Default is None.
-        jobs(int): Number of parallel jobs to run. Default is 1, which means sequentially.
-        backend(str): Parallelisation backend to use. Defaults to "joblib". 
-        verbose(bool): whether to display progress bars or not
+    :param pipeline: a transformer or pipeline to tune
+    :param params: a two-level dictionary, mapping transformer to param name to a list of values
+    :param topics_list: a *list* of topics dataframes to tune upon
+    :param qrels: qrels to tune upon. A single dataframe, or a list for each fold.       
+    :param metric: name of the metric on which to determine the most effective setting. Defaults to "map".
+    :param batch_size: If not None, evaluation is conducted in batches of batch_size topics. Default=None, which evaluates all topics at once. 
+        Applying a batch_size is useful if you have large numbers of topics, and/or if your pipeline requires large amounts of temporary memory
+        during a run. Default is None.
+    :param jobs: Number of parallel jobs to run. Default is 1, which means sequentially.
+    :param backend: Parallelisation backend to use. Defaults to "joblib". 
+    :param verbose(bool): whether to display progress bars or not
 
-    Returns:
-    A tuple containing, firstly, the results of pipeline on the test topics after tuning, and secondly, a list of the best parameter settings for each fold.
+    :return: A tuple containing, firstly, the results of pipeline on the test topics after tuning, and secondly, a list of the best parameter settings for each fold.
 
-    Consider tuning PL2 where folds of queries are pre-determined::
+    Consider tuning a terrier.Retriever PL2 where the folds of queries are pre-determined::
 
         pl2 = pt.terrier.Retriever(index, wmodel="PL2", controls={'c' : 1})
         tuned_pl2, _ = pt.KFoldGridSearch(
@@ -958,20 +956,19 @@ def GridSearch(
     with the best parameter settings among params, that were found that were obtained using the specified
     topics and qrels, and for the specified measure.
 
-    Args:
-        pipeline(Transformer): a transformer or pipeline to tune
-        params(dict): a two-level dictionary, mapping transformer to param name to a list of values
-        topics(DataFrame): topics to tune upon
-        qrels(DataFrame): qrels to tune upon       
-        metric(str): name of the metric on which to determine the most effective setting. Defaults to "map".
-        batch_size(int): If not None, evaluation is conducted in batches of batch_size topics. Default=None, which evaluates all topics at once. 
-            Applying a batch_size is useful if you have large numbers of topics, and/or if your pipeline requires large amounts of temporary memory
-            during a run. Default is None.
-        jobs(int): Number of parallel jobs to run. Default is 1, which means sequentially.
-        backend(str): Parallelisation backend to use. Defaults to "joblib". 
-        verbose(bool): whether to display progress bars or not
-        return_type(str): whether to return the same transformer with optimal pipeline setting, and/or a setting of the
-            higher metric value, and the resulting transformers and settings.
+    :param pipeline: a transformer or pipeline to tune
+    :param params: a two-level dictionary, mapping transformer to param name to a list of values
+    :param topics: topics to tune upon
+    :param qrels: qrels to tune upon       
+    :param metric: name of the metric on which to determine the most effective setting. Defaults to "map".
+    :param batch_size: If not None, evaluation is conducted in batches of batch_size topics. Default=None, which evaluates all topics at once. 
+        Applying a batch_size is useful if you have large numbers of topics, and/or if your pipeline requires large amounts of temporary memory
+        during a run. Default is None.
+    :param jobs: Number of parallel jobs to run. Default is 1, which means sequentially.
+    :param backend: Parallelisation backend to use. Defaults to "joblib". 
+    :param verbose: whether to display progress bars or not
+    :param return_type: whether to return the same transformer with optimal pipeline setting, and/or a setting of the
+        higher metric value, and the resulting transformers and settings.
     """
     # save state
     initial_state = _save_state(params)
@@ -1034,22 +1031,22 @@ def GridScan(
     varied must be changable using the :func:`set_parameter()` method. This means instance variables,
     as well as controls in the case of Retriever.
 
-    Args:
-        pipeline(Transformer): a transformer or pipeline
-        params(dict): a two-level dictionary, mapping transformer to param name to a list of values
-        topics(DataFrame): topics to tune upon
-        qrels(DataFrame): qrels to tune upon       
-        metrics(List[str]): name of the metrics to report for each setting. Defaults to ["map"].
-        batch_size(int): If not None, evaluation is conducted in batches of batch_size topics. Default=None, which evaluates all topics at once. 
-            Applying a batch_size is useful if you have large numbers of topics, and/or if your pipeline requires large amounts of temporary memory
-            during a run. Default is None.
-        jobs(int): Number of parallel jobs to run. Default is 1, which means sequentially.
-        backend(str): Parallelisation backend to use. Defaults to "joblib". 
-        verbose(bool): whether to display progress bars or not
-        dataframe(bool): return a dataframe or a list
-    Returns:
-        A dataframe showing the effectiveness of all evaluated settings, if dataframe=True
+    :param pipeline: a transformer or pipeline
+    :param params: a two-level dictionary, mapping transformer to param name to a list of values
+    :param topics: topics to tune upon
+    :param qrels: qrels to tune upon       
+    :param metrics): name of the metrics to report for each setting. Defaults to ["map"].
+    :param batch_size: If not None, evaluation is conducted in batches of batch_size topics. Default=None, which evaluates all topics at once. 
+        Applying a batch_size is useful if you have large numbers of topics, and/or if your pipeline requires large amounts of temporary memory
+        during a run. Default is None.
+    :param jobs: Number of parallel jobs to run. Default is 1, which means sequentially.
+    :param backend: Parallelisation backend to use. Defaults to "joblib". 
+    :param verbose: whether to display progress bars or not
+    :param dataframe: return a dataframe or a list
+
+    :return: A dataframe showing the effectiveness of all evaluated settings, if dataframe=True
         A list of settings and resulting evaluation measures, if dataframe=False
+    
     Raises:
         ValueError: if a specified transformer does not have such a parameter
 

--- a/pyterrier/terrier/index.py
+++ b/pyterrier/terrier/index.py
@@ -71,8 +71,8 @@ def treccollection2textgen(
     for parsing TREC-formatted corpora in indexers like IterDictIndexer, or similar 
     indexers in other plugins (e.g. ColBERTIndexer).
 
-    Arguments:
-     - files(List[str]): list of files to parse in TREC format.
+    "Arguments:
+     -" files(List[str]): list of files to parse in TREC format.
      - meta(List[str]): list of attributes to expose in the dictionaries as metadata.
      - meta_tags(Dict[str,str]): mapping of TREC tags as metadata.
      - tag_text_length(int): maximium length of metadata. Defaults to 4096.
@@ -227,16 +227,15 @@ class TerrierIndexer:
         Constructor called by all indexer subclasses. All arguments listed below are available in 
         IterDictIndexer, DFIndexer, TRECCollectionIndexer and FilesIndsexer. 
 
-        Args:
-            index_path (str): Directory to store index. Ignored for IndexingType.MEMORY.
-            blocks (bool): Create indexer with blocks if true, else without blocks. Default is False.
-            overwrite (bool): If index already present at `index_path`, True would overwrite it, False throws an Exception. Default is False.
-            verbose (bool): Provide progess bars if possible. Default is False.
-            stemmer (TerrierStemmer): the stemmer to apply. Default is ``TerrierStemmer.porter``.
-            stopwords (TerrierStopwords): the stopwords list to apply. Default is ``TerrierStemmer.terrier``.
-            tokeniser (TerrierTokeniser): the stemmer to apply. Default is ``TerrierTokeniser.english``.
-            type (IndexingType): the specific indexing procedure to use. Default is ``IndexingType.CLASSIC``.
-            properties (dict): Terrier properties that you wish to overrride.
+        :param index_path: Directory to store index. Ignored for IndexingType.MEMORY.
+        :param blocks: Create indexer with blocks if true, else without blocks. Default is False.
+        :param overwrite: If index already present at `index_path`, True would overwrite it, False throws an Exception. Default is False.
+        :param verbose: Provide progess bars if possible. Default is False.
+        :param stemmer: the stemmer to apply. Default is ``TerrierStemmer.porter``.
+        :param stopwords: the stopwords list to apply. Default is ``TerrierStemmer.terrier``.
+        :param tokeniser: the stemmer to apply. Default is ``TerrierTokeniser.english``.
+        :param type: the specific indexing procedure to use. Default is ``IndexingType.CLASSIC``.
+        :param properties: Terrier properties that you wish to overrride.
         """
         if type is IndexingType.MEMORY:
             self.path = None
@@ -545,15 +544,14 @@ class _BaseIterDictIndexer(TerrierIndexer, pt.Indexer):
                  **kwargs):
         """
         
-        Args:
-            index_path(str): Directory to store index. Ignored for IndexingType.MEMORY.
-            meta(Dict[str,int]): What metadata for each document to record in the index, and what length to reserve. Metadata values will be truncated to this length. Defaults to `{"docno" : 20}`.
-            text_attrs(List[str]): List of columns of the input data that should be indexed. These are concatenated in the document representation. Defaults to `["text"]`.
-            meta_reverse(List[str]): What metadata should we be able to resolve back to a docid. Defaults to `["docno"]`.
-            pretokenised(bool): Whether to index pre-tokenized text, e.g., through a Learned Sparse encoder. If True, will ignore ``text_attrs`` and indstead index the dictionary contained in the ``toks`` column.
-            fields(bool) : Whether a fields-indexer should be used, i.e. whether the frequency in each attribute should be recorded separately in the Terrer index. This allows application of weighting models such as BM25F.
-            threads(int): Number of threads to use for indexing. Defaults to 1.
-            kwargs: Additional keyword arguments passed to TerrierIndexer.
+        :param index_path: Directory to store index. Ignored for IndexingType.MEMORY.
+        :param meta: What metadata for each document to record in the index, and what length to reserve. Metadata values will be truncated to this length. Defaults to `{"docno" : 20}`.
+        :param text_attrs: List of columns of the input data that should be indexed. These are concatenated in the document representation. Defaults to `["text"]`.
+        :param meta_reverse: What metadata should we be able to resolve back to a docid. Defaults to `["docno"]`.
+        :param pretokenised: Whether to index pre-tokenized text, e.g., through a Learned Sparse encoder. If True, will ignore ``text_attrs`` and indstead index the dictionary contained in the ``toks`` column.
+        :param fields: Whether a fields-indexer should be used, i.e. whether the frequency in each attribute should be recorded separately in the Terrer index. This allows application of weighting models such as BM25F.
+        :param threads: Number of threads to use for indexing. Defaults to 1.
+        :param kwargs: Additional keyword arguments passed to TerrierIndexer.
         """
         pt.Indexer.__init__(self)
         TerrierIndexer.__init__(self, index_path, **kwargs)
@@ -651,8 +649,7 @@ class _IterDictIndexer_nofifo(_BaseIterDictIndexer):
         """
         Index the specified iter of dicts with the (optional) specified fields
 
-        Args:
-            it(iter[dict]): an iter of document dict to be indexed
+        :param it: an iter of document dicts to be indexed
         """
 
         if fields is not None:
@@ -715,8 +712,7 @@ class _IterDictIndexer_fifo(_BaseIterDictIndexer):
         """
         Index the specified iter of dicts with the (optional) specified fields
 
-        Args:
-            it(iter[dict]): an iter of document dict to be indexed
+        :param it: an iter of document dicts to be indexed
         """
         CollectionFromDocumentIterator = pt.terrier.J.CollectionFromDocumentIterator
         JsonlDocumentIterator = pt.terrier.J.JsonlDocumentIterator
@@ -844,15 +840,14 @@ class TRECCollectionIndexer(TerrierIndexer):
         """
         Init method
 
-        Args:
-            index_path (str): Directory to store index. Ignored for IndexingType.MEMORY.
-            blocks (bool): Create indexer with blocks if true, else without blocks. Default is False.
-            overwrite (bool): If index already present at `index_path`, True would overwrite it, False throws an Exception. Default is False.
-            type (IndexingType): the specific indexing procedure to use. Default is IndexingType.CLASSIC.
-            collection (Class name, or Class instance, or one of "trec", "trecweb", "warc"). Default is "trec".
-            meta(Dict[str,int]): What metadata for each document to record in the index, and what length to reserve. Metadata fields will be truncated to this length. Defaults to `{"docno" : 20}`.
-            meta_reverse(List[str]): What metadata shoudl we be able to resolve back to a docid. Defaults to `["docno"]`.
-            meta_tags(Dict[str,str]): For collections formed using tagged data (e.g. HTML), which tags correspond to which metadata. This is useful for recording the text of documents for use in neural rankers - see :ref:`pt.text`.
+        :param index_path: Directory to store index. Ignored for IndexingType.MEMORY.
+        :param blocks: Create indexer with blocks if true, else without blocks. Default is False.
+        :param overwrite: If index already present at `index_path`, True would overwrite it, False throws an Exception. Default is False.
+        :param type: the specific indexing procedure to use. Default is IndexingType.CLASSIC.
+        :param collection: name, or Class instance, or one of "trec", "trecweb", "warc"). Default is "trec".
+        :param meta: What metadata for each document to record in the index, and what length to reserve. Metadata fields will be truncated to this length. Defaults to `{"docno" : 20}`.
+        :param meta_reverse: What metadata shoudl we be able to resolve back to a docid. Defaults to `["docno"]`.
+        :param meta_tags: For collections formed using tagged data (e.g. HTML), which tags correspond to which metadata. This is useful for recording the text of documents for use in neural rankers - see :ref:`pt.text`.
 
         """
         super().__init__(index_path, **kwargs)
@@ -926,8 +921,7 @@ class FilesIndexer(TerrierIndexer):
         """
         Index the specified files.
 
-        Args:
-            files_path: can be a String of the path or a list of Strings of the paths for multiple files
+        :param files_path: can be a String of the path or a list of Strings of the paths for multiple files
         """
         self.checkIndexExists()
         index = self.createIndexer()

--- a/pyterrier/terrier/index_factory.py
+++ b/pyterrier/terrier/index_factory.py
@@ -98,9 +98,9 @@ class IndexFactory:
         """
         Loads an index. Returns a Terrier `Index <http://terrier.org/docs/current/javadoc/org/terrier/structures/Index.html>`_ object.
 
-        Args:
-            indexlike(str or IndexRef): Where is the index located
-            memory(bool or List[str]): If the index should be loaded into memory. Use `True` for all structures, or a list of structure names.
+        :param indexlike: The location of the index. This can be a string, or an `IndexRef <http://terrier.org/docs/current/javadoc/org/terrier/structures/IndexRef.html>`_ object.
+        :param memory: If the index should be loaded into memory. Use `True` for all structures, or a list of structure names.
+        :return: A Terrier `Index <http://terrier.org/docs/current/javadoc/org/terrier/structures/Index.html>`_ object.
         """
         load_profile = pt.terrier.J.IndexOnDisk.getIndexLoadingProfileAsRetrieval()
 

--- a/pyterrier/terrier/retriever.py
+++ b/pyterrier/terrier/retriever.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional
+from typing import Union, Optional, Callable, List, Any
 import pandas as pd
 import numpy as np
 from warnings import warn
@@ -116,8 +116,12 @@ class Retriever(pt.Transformer):
             version='latest',            
             **kwargs):
         """
-        Instantiates a Retriever object from a pre-built index access via a dataset.
+        Static method that instantiates a Retriever object from a pre-built index access via a dataset.
         Pre-built indices are ofen provided via the `Terrier Data Repository <http://data.terrier.org/>`_.
+
+        :param dataset: The name of the dataset, or a Dataset object that contains the index
+        :param variant: The variant of the index to use. If None, the default index will be used.
+        :param version: The version of the dataset to use. If None, the latest version will be used.
 
         Examples::
 
@@ -159,17 +163,24 @@ class Retriever(pt.Transformer):
         "termpipelines": "Stopwords,PorterStemmer"
     }
 
-    def __init__(self, index_location, controls=None, properties=None, metadata=["docno"],  num_results=None, wmodel=None, threads=1, verbose=False):
+    def __init__(self, 
+                 index_location : Union[str,Any], 
+                 controls : Optional[Dict[str,str]] = None, 
+                 properties : Optional[Dict[str,str]]= None, 
+                 metadata : List[str] = ["docno"], 
+                 num_results : Optional[int] = None, 
+                 wmodel : Optional[Union[str, Callable]] = None, 
+                 threads : int = 1, 
+                 verbose : bool = False):
         """
             Init method
 
-            Args:
-                index_location: An index-like object - An Index, an IndexRef, or a String that can be resolved to an IndexRef
-                controls(dict): A dictionary with the control names and values
-                properties(dict): A dictionary with the property keys and values
-                verbose(bool): If True transform method will display progress
-                num_results(int): Number of results to retrieve. 
-                metadata(list): What metadata to retrieve
+            :param index_location: An index-like object - An Index, an IndexRef, or a String that can be resolved to an IndexRef
+            :param controls: A dictionary with the control names and values
+            :param properties: A dictionary with the property keys and values
+            :param verbose: If True transform method will display progress
+            :param num_results: Number of results to retrieve. 
+            :param metadata: What metadata to retrieve. Default is ["docno"]. 
         """
         self.indexref = _parse_index_like(index_location)
         self.properties = _mergeDicts(Retriever.default_properties, properties)
@@ -365,12 +376,10 @@ class Retriever(pt.Transformer):
         """
         Performs the retrieval
 
-        Args:
-            queries: String for a single query, list of queries, or a pandas.Dataframe with columns=['qid', 'query']. For re-ranking,
+        :param queries: a pandas.Dataframe with columns=['qid', 'query']. For re-ranking,
                 the DataFrame may also have a 'docid' and or 'docno' column.
 
-        Returns:
-            pandas.Dataframe with columns=['qid', 'docno', 'rank', 'score']
+        :return: pandas.Dataframe with columns=['qid', 'docno', 'rank', 'score']
         """
         results=[]
         if not isinstance(queries, pd.DataFrame):
@@ -562,14 +571,13 @@ class TextScorer(TextIndexProcessor):
         A re-ranker class, which takes the queries and the contents of documents, indexes the contents of the documents using a MemoryIndex, and performs ranking of those documents with respect to the queries.
         Unknown kwargs are passed to Retriever.
 
-        Arguments:
-            takes(str): configuration - what is needed as input: `"queries"`, or `"docs"`. Default is `"docs"` since v0.8.
-            returns(str): configuration - what is needed as output: `"queries"`, or `"docs"`. Default is `"docs"`.
-            body_attr(str): what dataframe input column contains the text of the document. Default is `"body"`.
-            wmodel(str): name of the weighting model to use for scoring.
-            background_index(index_like): An optional background index to use for term and collection statistics. If a weighting
-                model such as BM25 or TF_IDF or PL2 is used without setting the background_index, the background statistics
-                will be calculated from the dataframe, which is ususally not the desired behaviour.
+        :param takes: configuration - what is needed as input: `"queries"`, or `"docs"`. Default is `"docs"` since v0.8.
+        :param returns: configuration - what is needed as output: `"queries"`, or `"docs"`. Default is `"docs"`.
+        :param body_attr: what dataframe input column contains the text of the document. Default is `"body"`.
+        :param wmodel: name of the weighting model to use for scoring.
+        :param background_index: An optional background index to use for term and collection statistics. If a weighting
+            model such as BM25 or TF_IDF or PL2 is used without setting the background_index, the background statistics
+            will be calculated from the dataframe, which is ususally not the desired behaviour.
 
         Example::
 
@@ -612,17 +620,22 @@ class FeaturesRetriever(Retriever):
     #: FBR_default_properties(dict): stores the default properties
     FBR_default_properties = Retriever.default_properties.copy()
 
-    def __init__(self, index_location, features, controls=None, properties=None, threads=1, **kwargs):
+    def __init__(self, 
+                 index_location : Union[str,Any], 
+                 features : List[str], 
+                 controls : Optional[Dict[str,str]] = None, 
+                 properties : Optional[Dict[str,str]] = None, 
+                 threads : int = 1, 
+                 **kwargs):
         """
             Init method
 
-            Args:
-                index_location: An index-like object - An Index, an IndexRef, or a String that can be resolved to an IndexRef
-                features(list): List of features to use
-                controls(dict): A dictionary with the control names and values
-                properties(dict): A dictionary with the property keys and values
-                verbose(bool): If True transform method will display progress
-                num_results(int): Number of results to retrieve. 
+            :param index_location: An index-like object - An Index, an IndexRef, or a String that can be resolved to an IndexRef
+            :param features: List of features to use
+            :param controls: A dictionary with the control names and values
+            :param properties: A dictionary with the property keys and values
+            :param verbose: If True transform method will display progress
+            :param num_results: Number of results to retrieve. 
         """
         controls = _mergeDicts(FeaturesRetriever.FBR_default_controls, controls)
         properties = _mergeDicts(FeaturesRetriever.FBR_default_properties, properties)
@@ -686,12 +699,10 @@ class FeaturesRetriever(Retriever):
         """
         Performs the retrieval with multiple features
 
-        Args:
-            queries: A pandas.Dataframe with columns=['qid', 'query']. For re-ranking,
+        :param queries: A pandas.Dataframe with columns=['qid', 'query']. For re-ranking,
                 the DataFrame may also have a 'docid' and or 'docno' column.
 
-        Returns:
-            pandas.DataFrame with columns=['qid', 'docno', 'score', 'features']
+        :return: a pandas.DataFrame with columns=['qid', 'docno', 'score', 'rank, 'features']
         """
         results = []
         if not isinstance(queries, pd.DataFrame):

--- a/pyterrier/transformer.py
+++ b/pyterrier/transformer.py
@@ -66,14 +66,14 @@ class Transformer:
         return IdentityTransformer()
 
     @staticmethod
-    def from_df(input : pd.DataFrame, uniform=False) -> 'Transformer':
+    def from_df(input : pd.DataFrame, uniform : bool = False) -> 'Transformer':
         """
         Instantiates a transformer from an input dataframe. Some rows from the input dataframe are returned
         in response to a query on the :meth:`transform` method. Depending on the value `uniform`, the dataframe
         passed as an argument to :meth:`transform` can affect this selection.
-        Arguments:
-                input(DataFrame): a dataframe to store and return, based on setting of `uniform`.
-                uniform(bool): If True, input will be returned in its entirety each time, else rows from input that match the qid values from the argument dataframe.
+
+        :param input: a dataframe to store and return, based on setting of `uniform`.
+        :param uniform: If True, input will be returned in its entirety each time, else rows from input that match the qid values from the argument dataframe.
         
         """
         if uniform:
@@ -93,12 +93,8 @@ class Transformer:
                 When :meth:`transform` is not implemented, the default implementation runs :meth:`transform_iter` and
                 converts the output to a ``DataFrame``.
 
-            Arguments:
-                inp(``pd.DataFrame``): The input to the transformer (e.g., queries, documents, results, etc.)
-
-            Returns:
-                The output of the transformer (e.g., result of retrieval, re-writing, re-ranking, etc.)
-
+            :param inp: The input to the transformer (e.g., queries, documents, results, etc.)
+            :return: The output of the transformer (e.g., result of retrieval, re-writing, re-ranking, etc.)
             :rtype: ``pd.DataFrame``
         """
         # We should have no recursive transform <-> transform_iter problem, due to the __new__ check.
@@ -121,12 +117,8 @@ class Transformer:
                 When :meth:`transform_iter` is not implemented, the default implementation runs :meth:`transform` and
                 converts the output to an iterable.
 
-            Arguments:
-                inp(``Iterable[Dict]``): The input to the transformer (e.g., queries, documents, results, etc.)
-
-            Returns:
-                The output of the transformer (e.g., result of retrieval, re-writing, re-ranking, etc.)
-
+            :param inp(``Iterable[Dict]``): The input to the transformer (e.g., queries, documents, results, etc.)
+            :return: The output of the transformer (e.g., result of retrieval, re-writing, re-ranking, etc.)
             :rtype: ``Iterable[Dict]``
         """
         # We should have no recursive transform <-> transform_iter problem, due to the __new__ check.
@@ -141,14 +133,9 @@ class Transformer:
             - Otherwise, invokes :meth:`transform_iter` and returns a generic iterable (returning whatever type is
               returned from :meth:`transform_iter()`.)
 
-            Arguments:
-                inp(``pd.DataFrame``, ``Iterable[Dict]``, ``List[Dict]``): The input to the transformer (e.g., queries,
-                    documents, results, etc.)
-
-            Returns:
-                The output of the transformer (e.g., result of retrieval, re-writing, re-ranking, etc.) as the same
+            :param inp: The input to the transformer (e.g., queries, documents, results, etc.)
+            :return: The output of the transformer (e.g., result of retrieval, re-writing, re-ranking, etc.) as the same
                 type as the input.
-
             :rtype: ``pd.DataFrame``, ``Iterable[Dict]``, ``List[Dict]``
         """
         if isinstance(inp, pd.DataFrame):
@@ -164,9 +151,8 @@ class Transformer:
             The input dataframe is grouped into batches of batch_size queries, and a generator
             returned, such that :meth:`transform` is only executed for a smaller batch at a time. 
 
-            Arguments:
-                input(DataFrame): a dataframe to process
-                batch_size(int): how many input instances to execute in each batch. Defaults to 1.
+            :param input: a dataframe to process
+            :param batch_size: how many input instances to execute in each batch. Defaults to 1.
             
         """
         docno_provided = "docno" in input.columns
@@ -198,14 +184,14 @@ class Transformer:
     def search(self, query : str, qid : str = "1", sort : bool = True) -> pd.DataFrame:
         """
             Method for executing a transformer (pipeline) for a single query. 
-            Returns a dataframe with the results for the specified query. This
-            is a utility method, and most uses are expected to use the :meth:`transform`
-            method passing a dataframe.
 
-            Arguments:
-                query(str): String form of the query to run
-                qid(str): the query id to associate to this request. defaults to 1.
-                sort(bool): ensures the results are sorted by descending rank (defaults to True)
+            :param query: String form of the query to run
+            :param qid: the query id to associate to this request. defaults to 1.
+            :param sort: ensures the results are sorted by descending rank (defaults to True)
+
+            :return: Returns a dataframe with the results for the specified query. This
+                is a utility method, and most uses are expected to use the :meth:`transform`
+                method passing a dataframe.
 
             Example::
 
@@ -230,19 +216,17 @@ class Transformer:
 
         For instance, a pipeline of transformers can be optimised by fusing adjacent transformers.
 
-        Returns:
-            A new transformer that is equivalent to this transformer, but optimised.
+        :return: A new transformer that is equivalent to this transformer, but optimised.
         """
         return self # by default, nothing to compile
 
-    def parallel(self, N : int, backend='joblib') -> 'Transformer':
+    def parallel(self, N : int, backend : str='joblib') -> 'Transformer':
         """
         Returns a parallelised version of this transformer. The underlying transformer must be "picklable". For more information, see
         :ref:`parallel` documentation.
 
-        Args:
-            N(int): how many processes/machines to parallelise this transformer over. 
-            backend(str): which multiprocessing backend to use. Only two backends are supported, 'joblib' and 'ray'. Defaults to 'joblib'.
+        :param N: how many processes/machines to parallelise this transformer over.
+        :param backend: which multiprocessing backend to use. Only two backends are supported, 'joblib' and 'ray'. Defaults to 'joblib'.
         """
         from .parallel import PoolParallelTransformer
         return PoolParallelTransformer(self, N, backend)
@@ -253,8 +237,7 @@ class Transformer:
             Gets the current value of a particular key of the transformer's configuration state.
             By default, this examines the attributes of the transformer object, using ``hasattr()`` and ``setattr()``.
 
-            Arguments:
-                name: name of parameter
+            :param name: name of parameter
         """
         if hasattr(self, name):
             return getattr(self, name)
@@ -267,9 +250,8 @@ class Transformer:
             Adjusts this transformer's configuration state, by setting the value for specific parameter.
             By default, this examines the attributes of the transformer object, using ``hasattr()`` and ``setattr()``.
 
-            Arguments:
-                name: name of parameter
-                value: current value of parameter
+            :param name: name of parameter
+            :param value: current value of parameter
 
         """
         if hasattr(self, name):
@@ -351,6 +333,8 @@ class Indexer(Transformer):
             an instance of the index or retriever. This method is typically used to implement indexers that
             consume a corpus (or to consume the output of previous pipeline components that have
             transformer the documents being consumed).
+
+            :param iter: An iterable of dictionaries, each representing a document.
         """
         pass
 
@@ -368,11 +352,10 @@ class Estimator(Transformer):
         """
             Method for training the transformer.
 
-            Arguments:
-                topics_or_res_tr(DataFrame): training topics (usually with documents)
-                qrels_tr(DataFrame): training qrels
-                topics_or_res_va(DataFrame): validation topics (usually with documents)
-                qrels_va(DataFrame): validation qrels
+            :param topics_or_res_tr: training topics (usually with documents)
+            :param qrels_tr: training qrels
+            :param topics_or_res_va: validation topics (usually with documents)
+            :param qrels_va: validation qrels
         """
         pass
 
@@ -439,8 +422,7 @@ class SupportsFuseRankCutoff(Protocol):
 
         If the fusion is not possible, `None` should be returned.
 
-        Arguments:
-            k(int): The rank cutoff requested
+        :param k: The rank cutoff requested
         """
 
 
@@ -452,9 +434,8 @@ class SupportsFuseFeatureUnion(Protocol):
         This method should return a new transformer that is equivalent to performing self ** other, or `None`
         if the fusion is not possible.
 
-        Arguments:
-                other(Transformer): transformer to the left or right.
-                is_left(bool): is True if self's features are to the left of other's. Otherwise, self's features are to the right.
+        :param other: transformer to the left or right.
+        :param is_left: is True if self's features are to the left of other's. Otherwise, self's features are to the right.
         """
 
 
@@ -473,12 +454,10 @@ class SupportsFuseLeft(Protocol):
         A fused transformer should be more efficient than the unfused version. For instance, a retriever
         followed by a rank cutoff can be fused to perform the rank cutoff during retrieval.
 
-        Arguments:
-            left(Transformer): transformer to the left.
+        :param left: transformer to the left.
 
-        Returns:
-            A new transformer that is the result of merging this transformer with the left transformer,
-            or none if a merge is not possible.
+        :return: A new transformer that is the result of merging this transformer with the left transformer,
+            or None if a merge is not possible.
         """
 
 
@@ -497,12 +476,10 @@ class SupportsFuseRight(Protocol):
         A fused transformer should be more efficient than the unfused version. For instance, a retriever
         followed by a rank cutoff can be fused to perform the rank cutoff during retrieval.
 
-        Arguments:
-            right(Transformer): transformer to the right in a composed pipeline.
+        :param right: transformer to the right in a composed pipeline.
 
-        Returns:
-            A new transformer that is the result of merging this transformer with the right transformer,
-            or none if a merge is not possible.
+        :return: A new transformer that is the result of merging this transformer with the right transformer,
+            or None if a merge is not possible.
         """
 
 


### PR DESCRIPTION
It turns out that Arguments with a list will not propagate types. :param notation does. This updates a lot of the documentation to use :param etc.

WIP