### PR TITLE
fix problem with huggingface upload

### DIFF
--- a/pyterrier/_artifact.py
+++ b/pyterrier/_artifact.py
@@ -396,8 +396,11 @@ class Artifact:
             try:
                 huggingface_hub.create_branch(repo, repo_type='dataset', branch=branch)
             except huggingface_hub.utils.HfHubHTTPError as e:
-                if not str(e.server_message).startswith('Reference already exists:'):
-                    raise
+                # detect the "already exists" error -- either as the 409 (Conflict) status code or 'already exists' appearing in the message
+                if (hasattr(e, 'response') and e.response.status_code == 409) or 'already exists' in str(e.server_message).lower():
+                    pass # ignore -- the branch already exists
+                else:
+                    raise # another error
 
             path = huggingface_hub.upload_folder(
                 repo_id=repo,


### PR DESCRIPTION
It looks like the've changed an error message we were using to detect when the branch already exists in huggingface hub. This change attempts to make the code a bit more robust by checking either the status code or a looser "already exists" string match.