### PR TITLE
migrate validate from pyterrier-alpha

### DIFF
--- a/docs/apply.rst
+++ b/docs/apply.rst
@@ -27,6 +27,10 @@ Objects that are passed to the function vary in terms of the type of the input d
 many rows (pd.DataFrame or list of dictionaries), and also vary in terms of what should be 
 returned by the function.
 
+.. hint:: 
+    It is usually a good idea to validate the inputs to make sure they contain the values you expect.
+    See :ref:`pyterrier.validate` for more details.
+
 +-------+---------+-------------+------------------+---------------------------+-------------------------------------+-------------------------------------------+
 + Input | Output  | Cardinality | Example          | Example apply             | Function Input type                 | Function Return type                      |
 +=======+=========+=============+==================+===========================+=====================================+===========================================+
@@ -53,6 +57,7 @@ PyTerrier transformers through the standard PyTerrier operators.
 
 If `verbose=True` is passed to any pyterrier apply method (except `generic()`), then a `TQDM <https://tqdm.github.io/>`_ 
 progress bar will be shown as the transformer is applied.
+
 
 Example
 =======

--- a/docs/extending/index.rst
+++ b/docs/extending/index.rst
@@ -14,3 +14,4 @@ PyTerrier is designed to be extensible. This section describes how to extend PyT
    packages
    datasets
    indexer_retrieval
+   validate

--- a/docs/extending/validate.rst
+++ b/docs/extending/validate.rst
@@ -1,3 +1,5 @@
+.. _pyterrier.validate:
+
 Input Validation
 ===================================
 

--- a/docs/extending/validate.rst
+++ b/docs/extending/validate.rst
@@ -1,0 +1,87 @@
+Input Validation
+===================================
+
+DataFrame Validation
+------------------------------------
+
+When writing a transformer, it's a good idea to check its inputs to make sure they are compatible
+before you start using it. ``pt.validate`` provides functions for this.
+
+.. code-block:: python
+    :caption: DataFrame input validation in a Transformer
+
+    def MyTransformer(pt.Transformer):
+        def transform(self, inp: pd.DataFrame):
+            # e.g., expects a query frame with query_vec
+            pt.validate.query_frame(inp, extra_columns=['query_vec'])
+            # raises an error if the specification doesn't match
+
+=========================================================  ===============================  =======================
+Function                                                   Must have column(s)              Must NOT have column(s)
+=========================================================  ===============================  =======================
+``pt.validate.query_frame(inp, extra_columns=...)``        qid + ``extra_columns``          docno
+``pt.validate.document_frame(inp, extra_columns=...)``     docno + ``extra_columns``        qid
+``pt.validate.result_frame(inp, extra_columns=...)``       qid + docno + ``extra_columns``  
+``pt.validate.columns(inp, includes=..., excludes=...)``   ``includes``                     ``excludes``
+=========================================================  ===============================  =======================
+
+
+.. note::
+    Besides providing helpful error messages to users, these methods also help perform inspection of pipelines, e.g.,
+    for drawing pipeline schematic representations of pipelines and ensuring that transformers are compatible before
+    running them.
+
+
+Iterable validation
+------------------------------------
+
+For indexing pipelines that accept iterators, it checks the fields of the first element. You need
+to first wrap `inp` in ``pt.utils.peekable()`` for this to work.
+
+.. code-block:: python
+    :caption: Iterable input validation in a Transformer
+
+    my_iterator = [{'docno': 'doc1'}, {'docno': 'doc2'}, {'docno': 'doc3'}]
+    my_iterator = pt.utils.peekable(my_iterator)
+    pt.validate.columns_iter(my_iterator, includes=['docno']) # passes
+    pt.validate.columns_iter(my_iterator, includes=['docno', 'toks']) # raises errors
+
+Advanced Usage
+------------------------------------------
+
+Sometimes a transformer has multiple acceptable input specifications, e.g., if
+it can act as either a retriever (with a query input) or re-ranker (with a result input).
+In this case, you can specify multiple possible configurations in a ``with pt.validate.any(inpt) as v:`` block:
+
+.. code-block:: python
+    :caption: Validation with multiple acceptable input specifications
+
+    def MyTransformer(pt.Transformer):
+        def transform(self, inp: pd.DataFrame):
+            # e.g., expects a query frame with query_vec
+            with pt.validate.any(inp) as v:
+                v.query_frame(extra_columns=['query'], mode='retrieve')
+                v.result_frame(extra_columns=['query', 'text'], mode='rerank')
+            # raises an error if ALL specifications do not match
+            # v.mode is set to the FIRST specification that matches
+            if v.mode == 'retrieve':
+                ...
+            if v.mode == 'rerank':
+                ...
+
+API Documentation
+---------------------------------------------------------
+
+.. autofunction:: pyterrier.validate.columns
+
+.. autofunction:: pyterrier.validate.query_frame
+
+.. autofunction:: pyterrier.validate.result_frame
+
+.. autofunction:: pyterrier.validate.document_frame
+
+.. autofunction:: pyterrier.validate.columns_iter
+
+.. autofunction:: pyterrier.validate.any
+
+.. autofunction:: pyterrier.validate.any_iter

--- a/docs/extending/validate.rst
+++ b/docs/extending/validate.rst
@@ -80,8 +80,14 @@ API Documentation
 
 .. autofunction:: pyterrier.validate.document_frame
 
+.. autofunction:: pyterrier.validate.any
+
 .. autofunction:: pyterrier.validate.columns_iter
 
-.. autofunction:: pyterrier.validate.any
+.. autofunction:: pyterrier.validate.query_iter
+
+.. autofunction:: pyterrier.validate.document_iter
+
+.. autofunction:: pyterrier.validate.result_iter
 
 .. autofunction:: pyterrier.validate.any_iter

--- a/docs/transformer.rst
+++ b/docs/transformer.rst
@@ -39,6 +39,10 @@ Depending on the expected input and output column of a transformer, they can be 
 | Q x D |  Q x Df |   1 to 1    | Feature scoring     | `pt.terrier.FeaturesRetriever()`                                                         |
 +-------+---------+-------------+---------------------+------------------------------------------------------------------------------------------+
 
+.. hint:: 
+    When writing transformers, it's a good idea to validate the inputs to make sure they contain the values you expect.
+    See :ref:`pyterrier.validate` for more details.
+
 Optimisation
 ============
 

--- a/pyterrier/__init__.py
+++ b/pyterrier/__init__.py
@@ -4,7 +4,7 @@ __version__ = '0.13.1'
 from typing import Any
 from deprecated import deprecated
 
-from pyterrier import model, utils
+from pyterrier import model, utils, validate
 from pyterrier.transformer import Transformer, Estimator, Indexer
 from pyterrier._ops import RankCutoff, Compose
 from pyterrier._artifact import Artifact
@@ -58,10 +58,9 @@ cast = deprecated(version='0.11.0', reason="use pt.java.cast(...) instead")(java
 
 __all__ = [
     'java', 'terrier', 'cache', 'debug', 'io', 'inspect', 'measures', 'model', 'new', 'ltr', 'parallel', 'pipelines',
-    'text', 'transformer', 'datasets', 'get_dataset', 'find_datasets', 'list_datasets', 'Experiment', 'GridScan',
+    'text', 'transformer', 'datasets', 'validate', 'get_dataset', 'find_datasets', 'list_datasets', 'Experiment', 'GridScan',
     'GridSearch', 'KFoldGridSearch', 'Evaluate',
     'utils', 'Utils', 'Transformer', 'Estimator', 'Indexer', 'Artifact',
-    'utils', 'Utils', 'Transformer', 'Estimator', 'Indexer',
     'RankCutoff', 'Compose',
     'BatchRetrieve', 'TerrierRetrieve', 'FeaturesBatchRetrieve', 'IndexFactory',
     'run', 'rewrite', 'index', 'FilesIndexer', 'TRECCollectionIndexer', 'DFIndexer', 'DFIndexUtils', 'IterDictIndexer',

--- a/pyterrier/utils.py
+++ b/pyterrier/utils.py
@@ -1,7 +1,7 @@
 import os
 import inspect
 import sys
-from typing import Tuple, List, Callable, Set, Sequence
+from typing import Tuple, List, Callable, Set, Sequence, Union, Iterator, Iterable, Any
 from contextlib import contextmanager
 import platform
 from functools import wraps
@@ -175,3 +175,38 @@ class GeneratorLen(object):
 
     def __iter__(self):
         return self.gen
+
+
+_NO_BUFFER = object()
+
+
+class PeekableIter:
+    """An iterator that allows peeking at the next element."""
+    def __init__(self, base: Union[Iterator, Iterable]):
+        """Create a PeekableIter from an iterator or iterable."""
+        self.base = iter(base)
+        self._buffer = _NO_BUFFER
+
+    def __getattr__(self, attr: str):
+        return getattr(self.base, attr)
+
+    def __next__(self):
+        if self._buffer != _NO_BUFFER:
+            n = self._buffer
+            self._buffer = _NO_BUFFER
+            return n
+        return next(self.base)
+
+    def __iter__(self):
+        return self
+
+    def peek(self) -> Any:
+        """Return the next element without consuming it."""
+        if self._buffer == _NO_BUFFER:
+            self._buffer = next(self.base)
+        return self._buffer
+
+
+def peekable(it: Union[Iterator, Iterable]) -> PeekableIter:
+    """Create a PeekableIter from an iterator or iterable."""
+    return PeekableIter(it)

--- a/pyterrier/validate.py
+++ b/pyterrier/validate.py
@@ -122,7 +122,7 @@ def document_frame(inp: pd.DataFrame, extra_columns: Optional[List[str]] = None,
         v.document_frame(extra_columns)
 
 
-def columns_iter(inp: 'pyterrier.utils.PeekableIter',
+def columns_iter(inp: 'pt.utils.PeekableIter',
             *,
             includes: Optional[List[str]] = None,
             excludes: Optional[List[str]] = None,
@@ -148,7 +148,7 @@ def any(inp: Union[pd.DataFrame, List[str]], warn: bool = False) -> '_Validation
     return _ValidationContextManager(inp, warn=warn)
 
 
-def any_iter(inp: 'pyterrier.utils.PeekableIter', warn: bool = False) -> '_IterValidationContextManager':
+def any_iter(inp: 'pt.utils.PeekableIter', warn: bool = False) -> '_IterValidationContextManager':
     """Create a validation context manager for an iterator."""
     if not isinstance(inp, pt.utils.PeekableIter):
         raise AttributeError('inp is not peekable. Run the following before calling this function.\n'
@@ -234,7 +234,7 @@ class _ValidationContextManager:
 _EMPTY_ITER = object()
 
 class _IterValidationContextManager:
-    def __init__(self, inp: 'pyterrier.utils.PeekableIter', warn: bool = False):
+    def __init__(self, inp: 'pt.utils.PeekableIter', warn: bool = False):
         try:
             self.sample_cols = set(inp.peek().keys())
         except StopIteration:

--- a/pyterrier/validate.py
+++ b/pyterrier/validate.py
@@ -1,0 +1,310 @@
+"""Validation utilities for checking the inputs of transformers."""
+import warnings
+from types import TracebackType
+from typing import List, Optional, Type, Union
+import pandas as pd
+import pyterrier as pt
+
+
+class _TransformerMode:
+    def __init__(self, missing_columns: List[str], extra_columns: List[str], mode_name: Optional[str] = None):
+        self.missing_columns = missing_columns
+        self.extra_columns = extra_columns
+        self.mode_name = mode_name
+
+    def __str__(self):
+        return f'{self.mode_name} (missing: {self.missing_columns}, extra: {self.extra_columns})'
+
+    def __repr__(self):
+        return f'TransformerMode(missing_columns={self.missing_columns!r}, ' \
+               f'extra_columns={self.extra_columns!r}, ' \
+               f'mode_name={self.mode_name!r})'
+
+
+class InputValidationError(KeyError):
+    """Exception raised when input validation fails."""
+    def __init__(self, message: str, modes: List[_TransformerMode]):
+        """Create an InputValidationError."""
+        assert len(modes) > 0
+        super().__init__(message)
+        self.modes = modes
+
+    def __str__(self):
+        return self.args[0] + ' ' + str(self.modes)
+
+    def __repr__(self):
+        return f'InputValidationError({self.args[0]!r}, {self.modes!r})'
+
+
+class InputValidationWarning(Warning):
+    """Warning raised when input validation fails in warn mode."""
+    pass
+
+
+def columns(inp: pd.DataFrame,
+            *,
+            includes: Optional[List[str]] = None,
+            excludes: Optional[List[str]] = None,
+            warn: bool = False) -> None:
+    """Check that the input frame has the expected columns.
+
+    Args:
+        inp: Input DataFrame to validate
+        includes: List of required columns
+        excludes: List of forbidden columns
+        warn: If True, raise warnings instead of exceptions for validation errors
+
+    Raises:
+        InputValidationError: If warn=False and validation fails
+        InputValidationWarning: If warn=True and validation fails
+
+    .. versionchanged:: 0.15.0
+        Accept ``List[str]`` inp columns
+    """
+    with any(inp, warn=warn) as v:
+        v.columns(includes=includes, excludes=excludes)
+
+
+def query_frame(inp: pd.DataFrame, extra_columns: Optional[List[str]] = None, warn: bool = False) -> None:
+    """Check that the input frame is a valid query frame.
+
+    Args:
+        inp: Input DataFrame to validate
+        extra_columns: Additional required columns
+        warn: If True, raise warnings instead of exceptions for validation errors
+
+    Raises:
+        InputValidationError: If warn=False and validation fails
+        InputValidationWarning: If warn=True and validation fails
+
+    .. versionchanged:: 0.15.0
+        Accept ``List[str]`` inp columns
+    """
+    with any(inp, warn=warn) as v:
+        v.query_frame(extra_columns)
+
+
+def result_frame(inp: pd.DataFrame, extra_columns: Optional[List[str]] = None, warn: bool = False) -> None:
+    """Check that the input frame is a valid result frame.
+
+    Args:
+        inp: Input DataFrame to validate
+        extra_columns: Additional required columns
+        warn: If True, raise warnings instead of exceptions for validation errors
+
+    Raises:
+        InputValidationError: If warn=False and validation fails
+        InputValidationWarning: If warn=True and validation fails
+
+    .. versionchanged:: 0.15.0
+        Accept ``List[str]`` inp columns
+    """
+    with any(inp, warn=warn) as v:
+        v.result_frame(extra_columns)
+
+
+def document_frame(inp: pd.DataFrame, extra_columns: Optional[List[str]] = None, warn: bool = False) -> None:
+    """Check that the input frame is a valid document frame.
+
+    Args:
+        inp: Input DataFrame to validate
+        extra_columns: Additional required columns
+        warn: If True, raise warnings instead of exceptions for validation errors
+
+    Raises:
+        InputValidationError: If warn=False and validation fails
+        InputValidationWarning: If warn=True and validation fails
+
+    .. versionchanged:: 0.15.0
+        Accept ``List[str]`` inp columns
+    """
+    with any(inp, warn=warn) as v:
+        v.document_frame(extra_columns)
+
+
+def columns_iter(inp: 'pyterrier.utils.PeekableIter',
+            *,
+            includes: Optional[List[str]] = None,
+            excludes: Optional[List[str]] = None,
+            warn: bool = False) -> None:
+    """Check that the input frame has the expected columns.
+
+    Args:
+        inp: Input DataFrame to validate
+        includes: List of required columns
+        excludes: List of forbidden columns
+        warn: If True, raise warnings instead of exceptions for validation errors
+
+    Raises:
+        InputValidationError: If warn=False and validation fails
+        InputValidationWarning: If warn=True and validation fails
+    """
+    with any_iter(inp, warn=warn) as v:
+        v.columns(includes=includes, excludes=excludes)
+
+
+def any(inp: Union[pd.DataFrame, List[str]], warn: bool = False) -> '_ValidationContextManager':
+    """Create a validation context manager for a DataFrame."""
+    return _ValidationContextManager(inp, warn=warn)
+
+
+def any_iter(inp: 'pyterrier.utils.PeekableIter', warn: bool = False) -> '_IterValidationContextManager':
+    """Create a validation context manager for an iterator."""
+    if not isinstance(inp, pt.utils.PeekableIter):
+        raise AttributeError('inp is not peekable. Run the following before calling this function.\n'
+                             'inp = pta.utils.peekable(inp) # !! IMPORTANT: you must re-assign the input to peekable '
+                             '(not just pass it in), otherwise you will skip the first record !!')
+    return _IterValidationContextManager(inp, warn=warn)
+
+
+class _ValidationContextManager:
+    """Context manager for validating the input to transformers."""
+    def __init__(self, inp: Union[pd.DataFrame, List[str]], warn: bool = False):
+        """Create a ValidationContextManager for the given DataFrame."""
+        if isinstance(inp, pd.DataFrame):
+            self.inp_columns = list(inp.columns)
+        else:
+            self.inp_columns = inp
+        self.mode = None
+        self.attempts = 0
+        self.errors = []
+        self.warn = warn
+
+    def __enter__(self):
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        traceback: Optional[TracebackType]
+    ) -> Optional[bool]:
+
+        if exc_type is not None:
+            return False # the captured exception takes priority
+
+        if self.attempts > 0 and self.attempts == len(self.errors):
+            message = "DataFrame does not match required columns for this transformer."
+            if self.warn:
+                warnings.warn(f"{message} {self.errors}", InputValidationWarning)
+            else:
+                raise InputValidationError(message, self.errors)
+
+    def columns(self,
+                *,
+                includes: Optional[List[str]] = None,
+                excludes: Optional[List[str]] = None,
+                mode: str = None) -> bool:
+        """Check that the input frame has the ``includes`` columns and doesn't have the ``excludes`` columns."""
+        includes = includes if includes is not None else []
+        excludes = excludes if excludes is not None else []
+        missing_columns = set(includes) - set(self.inp_columns)
+        extra_columns = set(excludes) & set(self.inp_columns)
+        self.attempts += 1
+
+        if missing_columns or extra_columns:
+            self.errors.append(_TransformerMode(
+                missing_columns=[c for c in includes if c in missing_columns],
+                extra_columns=[c for c in excludes if c in extra_columns],
+                mode_name=mode,
+            ))
+            return False
+
+        if self.mode is None and mode is not None:
+            self.mode = mode
+
+        return True
+
+    def query_frame(self, extra_columns: Optional[List[str]] = None, mode: str = None) -> bool:
+        """Check that the input frame is a valid query frame, with optional extra columns."""
+        extra_columns = list(extra_columns) if extra_columns is not None else []
+        return self.columns(includes=['qid'] + extra_columns, excludes=['docno'], mode=mode)
+
+    def result_frame(self, extra_columns: Optional[List[str]] = None, mode: str = None) -> bool:
+        """Check that the input frame is a valid result frame, with optional extra columns."""
+        extra_columns = list(extra_columns) if extra_columns is not None else []
+        return self.columns(includes=['qid', 'docno'] + extra_columns, mode=mode)
+
+    def document_frame(self, extra_columns: Optional[List[str]] = None, mode: str = None) -> bool:
+        """Check that the input frame is a valid document frame, with optional extra columns."""
+        extra_columns = list(extra_columns) if extra_columns is not None else []
+        return self.columns(includes=['docno'] + extra_columns, excludes=['qid'], mode=mode)
+
+
+_EMPTY_ITER = object()
+
+class _IterValidationContextManager:
+    def __init__(self, inp: 'pyterrier.utils.PeekableIter', warn: bool = False):
+        try:
+            self.sample_cols = set(inp.peek().keys())
+        except StopIteration:
+            self.sample_cols = _EMPTY_ITER
+        self.mode = None
+        self.attempts = 0
+        self.errors = []
+        self.warn = warn
+
+    def __enter__(self):
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        traceback: Optional[TracebackType]
+    ) -> Optional[bool]:
+
+        if exc_type is not None:
+            return False # the captured exception takes priority
+
+        if self.attempts > 0 and self.attempts == len(self.errors):
+            message = "Input does not match required columns for this transformer."
+            if self.warn:
+                warnings.warn(f"{message} {self.errors}", InputValidationWarning)
+            else:
+                raise InputValidationError(message, self.errors)
+
+    def columns(self,
+                *,
+                includes: Optional[List[str]] = None,
+                excludes: Optional[List[str]] = None,
+                mode: str = None) -> bool:
+        self.attempts += 1
+        includes = includes if includes is not None else []
+        excludes = excludes if excludes is not None else []
+        if self.sample_cols == _EMPTY_ITER:
+            self.errors.append(_TransformerMode(
+                missing_columns=list(includes),
+                extra_columns=[],
+                mode_name=mode,
+            ))
+            return False
+        missing_columns = set(includes) - self.sample_cols
+        extra_columns = set(excludes) & self.sample_cols
+
+        if missing_columns or extra_columns:
+            self.errors.append(_TransformerMode(
+                missing_columns=[c for c in includes if c in missing_columns],
+                extra_columns=[c for c in excludes if c in extra_columns],
+                mode_name=mode,
+            ))
+            return False
+
+        if self.mode is None and mode is not None:
+            self.mode = mode
+
+        return True
+
+    def empty(self, *, mode: str = 'empty'):
+        self.attempts += 1
+        if self.sample_cols != _EMPTY_ITER:
+            self.errors.append(_TransformerMode(
+                missing_columns=[],
+                extra_columns=[],
+                mode_name=mode,
+            ))
+            return False
+
+        if self.mode is None and mode is not None:
+            self.mode = mode
+        return True

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -1,5 +1,6 @@
 import unittest
 import tempfile
+import urllib
 import pyterrier as pt
 from .base import BaseTestCase
 
@@ -12,7 +13,11 @@ class TestArtifact(BaseTestCase):
         #  - loading correct artifact type
         #  - build_package
         for mem in [True, False]:
-            index = pt.Artifact.from_hf('pyterrier/vaswani.terrier', memory=mem)
+            try:
+                index = pt.Artifact.from_hf('pyterrier/vaswani.terrier', memory=mem)
+            except urllib.error.HTTPError as ex:
+                if ex.code != 429: # too many requests ... can just ignore
+                    raise
             retr = index.bm25(num_results=10)
             self.assertEqual(10, len(retr.search('chemical reactions')))
         with tempfile.TemporaryDirectory() as d:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,165 @@
+import unittest
+import warnings
+import pandas as pd
+import pyterrier as pt
+
+
+class TestValidate(unittest.TestCase):
+    def test_columns_valid(self):
+        with self.subTest('df'):
+            pt.validate.columns(
+                pd.DataFrame({'qid': [1, 2], 'text': ['hello', 'world']}),
+                includes=['qid'],
+                excludes=['docno'])
+        with self.subTest('cols'):
+            pt.validate.columns(
+                ['qid', 'text'],
+                includes=['qid'],
+                excludes=['docno'])
+        with self.subTest('iterdict'):
+            pt.validate.columns_iter(
+                pt.utils.peekable([{'qid': '1', 'text': '0'}]),
+                includes=['qid'],
+                excludes=['docno'])
+
+    def test_columns_missing_column(self):
+        with self.subTest('df'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.columns(
+                    pd.DataFrame({'text': ['hello', 'world']}),
+                    includes=['qid'])
+            self.assertIn('qid', cm.exception.modes[0].missing_columns)
+        with self.subTest('cols'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.columns(
+                    ['text', 'other'],
+                    includes=['qid'])
+            self.assertIn('qid', cm.exception.modes[0].missing_columns)
+        with self.subTest('iterdict'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.columns_iter(
+                    pt.utils.peekable([{'text': 'hello', 'other': 'world'}]),
+                    includes=['qid'])
+            self.assertIn('qid', cm.exception.modes[0].missing_columns)
+
+    def test_columns_extra_column(self):
+        with self.subTest('df'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.columns(
+                    pd.DataFrame({'qid': [1, 2], 'docno': [3, 4]}),
+                    includes=['qid'],
+                    excludes=['docno'])
+            self.assertIn('docno', cm.exception.modes[0].extra_columns)
+        with self.subTest('cols'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.columns(
+                    ['qid', 'docno'],
+                    includes=['qid'],
+                    excludes=['docno'])
+            self.assertIn('docno', cm.exception.modes[0].extra_columns)
+        with self.subTest('iterdict'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.columns_iter(
+                    pt.utils.peekable([{'qid': '1', 'docno': '2'}]),
+                    includes=['qid'],
+                    excludes=['docno'])
+            self.assertIn('docno', cm.exception.modes[0].extra_columns)
+
+    def test_columns_warn_mode(self):
+        with self.subTest('df'):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                pt.validate.columns(pd.DataFrame({'text': ['hello', 'world']}), includes=['qid'], warn=True)
+                self.assertEqual(len(w), 1)
+                self.assertTrue(issubclass(w[0].category, pt.validate.InputValidationWarning))
+                self.assertIn("DataFrame does not match required columns", str(w[0].message))
+        with self.subTest('cols'):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                pt.validate.columns(['text', 'other'], includes=['qid'], warn=True)
+                self.assertEqual(len(w), 1)
+                self.assertTrue(issubclass(w[0].category, pt.validate.InputValidationWarning))
+                self.assertIn("DataFrame does not match required columns", str(w[0].message))
+        with self.subTest('iterdict'):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                pt.validate.columns_iter(
+                    pt.utils.peekable([{'text': 'hello', 'other': 'world'}]),
+                    includes=['qid'],
+                    warn=True)
+                self.assertEqual(len(w), 1)
+                self.assertTrue(issubclass(w[0].category, pt.validate.InputValidationWarning))
+                self.assertIn("Input does not match required columns", str(w[0].message))
+
+    def test_query_frame_valid(self):
+        with self.subTest('df'):
+            pt.validate.query_frame(pd.DataFrame({'qid': [1, 2], 'query': ['cat', 'dog'], 'a': [1, 2]}), extra_columns=['a'])
+        with self.subTest('cols'):
+            pt.validate.query_frame(['qid', 'query', 'a'], extra_columns=['a'])
+        with self.subTest('iterdict'):
+            pt.validate.query_iter(pt.utils.peekable([{'qid': '1', 'query': 'cat', 'a': 1}]), extra_columns=['a'])
+
+    def test_query_frame_invalid(self):
+        with self.subTest('df'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.query_frame(pd.DataFrame({'query': ['cat', 'dog']}))
+            self.assertIn('qid', cm.exception.modes[0].missing_columns)
+        with self.subTest('cols'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.query_frame(['query'])
+            self.assertIn('qid', cm.exception.modes[0].missing_columns)
+        with self.subTest('iterdict'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.query_iter(pt.utils.peekable([{'query': 'cat'}]))
+            self.assertIn('qid', cm.exception.modes[0].missing_columns)
+
+    def test_document_frame_valid(self):
+        with self.subTest('df'):
+            pt.validate.document_frame(pd.DataFrame({'docno': [101, 102], 'text': ['hello', 'world']}))
+        with self.subTest('cols'):
+            pt.validate.document_frame(['docno', 'text'])
+        with self.subTest('iterdict'):
+            pt.validate.document_iter(pt.utils.peekable([{'docno': '101', 'text': 'hello'}]))
+
+    def test_document_frame_invalid(self):
+        with self.subTest('df'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.document_frame(pd.DataFrame({'text': ['hello', 'world']}))
+            self.assertIn('docno', cm.exception.modes[0].missing_columns)
+        with self.subTest('cols'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.document_frame(['text'])
+            self.assertIn('docno', cm.exception.modes[0].missing_columns)
+        with self.subTest('iterdict'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.document_iter(pt.utils.peekable([{'text': 'hello'}]))
+            self.assertIn('docno', cm.exception.modes[0].missing_columns)
+
+    def test_result_frame_valid(self):
+        with self.subTest('df'):
+            pt.validate.result_frame(pd.DataFrame({'qid': [1, 2], 'docno': [101, 102], 'score': [0.8, 0.6]}))
+        with self.subTest('cols'):
+            pt.validate.result_frame(['qid', 'docno', 'score'])
+        with self.subTest('iterdict'):
+            pt.validate.result_iter(pt.utils.peekable([{'qid': '1', 'docno': '101', 'score': 0.8}]))
+
+    def test_result_frame_invalid(self):
+        with self.subTest('df'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.result_frame(pd.DataFrame({'score': [0.8, 0.6]}))
+            self.assertIn('qid', cm.exception.modes[0].missing_columns)
+            self.assertIn('docno', cm.exception.modes[0].missing_columns)
+        with self.subTest('cols'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.result_frame(['score'])
+            self.assertIn('qid', cm.exception.modes[0].missing_columns)
+            self.assertIn('docno', cm.exception.modes[0].missing_columns)
+        with self.subTest('iterdict'):
+            with self.assertRaises(pt.validate.InputValidationError) as cm:
+                pt.validate.result_iter(pt.utils.peekable([{'score': 0.8}]))
+            self.assertIn('qid', cm.exception.modes[0].missing_columns)
+            self.assertIn('docno', cm.exception.modes[0].missing_columns)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Migrating `pta.validate` from `pyterrier-alpha`.

`pta.validate` provides tools for checking the inputs of transformers. It's [pretty widely used](https://github.com/search?q=%22pta.validate%22&type=code) throughout extension packages and sufficiently mature to move into core.

TODO:
 - [x] unit tests
 - [x] passing `List[str]` instead of dataframe seems to only be partially supported ... check on this during testing
 - [x] ruff/mypy errors


Migration plan: [pyterrier-alpha/migrate-validate](https://github.com/seanmacavaney/pyterrier-alpha/tree/migrate-validate) will replace the existing implementations with those from core, once it's merged and released. Packages can then migrate to core's implementation without disruption.