### PR TITLE
Funion inspect

### DIFF
--- a/pyterrier/_ops.py
+++ b/pyterrier/_ops.py
@@ -35,27 +35,6 @@ class NAryTransformerBase(Transformer):
             Returns an iterator over the transformers in this pipeline.
         """
         return iter(self._transformers)
-    
-    @staticmethod
-    def _minimal_inputs(all_configs : List[List[List[str]]]) -> List[str]:
-        all_configs_sets = [ 
-            set(a) for tconfig in all_configs for a in tconfig
-        ]
-        
-        from itertools import chain, combinations
-        # universe of all columns
-        universe = set(chain.from_iterable(all_configs_sets))
-
-        # test subsets in increasing size
-        plausible = []
-        for r in range(1, len(universe) + 1):
-            for subset in combinations(universe, r):
-                subset = set(subset)
-                # Check if subset works for all objects
-                if all(any(set(schema).issubset(subset) for schema in obj) for obj in all_configs):
-                    plausible.append(list(subset))
-        return plausible
-
 
 def _flatten(transformers: Iterable[Transformer], cls: type) -> Tuple[Transformer, ...]:
     return tuple(chain.from_iterable(
@@ -248,7 +227,7 @@ class FeatureUnion(NAryTransformerBase):
 
     def transform_inputs(self) -> List[List[str]]:
         this_minimum = [[['qid', 'docno']]]
-        return NAryTransformerBase._minimal_inputs(this_minimum + [ 
+        return pt.inspect._minimal_inputs(this_minimum + [ 
             pt.inspect.transformer_inputs(t) for t in self._transformers
         ])
 

--- a/pyterrier/apply.py
+++ b/pyterrier/apply.py
@@ -169,8 +169,12 @@ def rename(columns : Dict[str,str], *args, errors : Literal['raise', 'ignore']='
     else:
         required_columns = None
     t = ApplyGenericTransformer(lambda df: df.rename(columns=columns, errors=errors), *args, required_columns=required_columns, **kwargs)
-    t._schematic_title = "Rename Columns"
-    t._schematic_settings = {"columns": columns}
+    t.schematic = {
+        "label": "Rename Columns",
+        "input_columns" : columns.keys(),
+        "output_columns": columns.values(),
+        "settings" :  {"columns": columns}
+    }
     return t
 
 def generic(fn : Union[Callable[[pd.DataFrame], pd.DataFrame], Callable[[pt.model.IterDict], pt.model.IterDict]], *args, batch_size=None, iter=False, **kwargs) -> pt.Transformer:

--- a/pyterrier/inspect.py
+++ b/pyterrier/inspect.py
@@ -390,6 +390,28 @@ def subtransformers(transformer: pt.Transformer) -> Dict[str, Union[pt.Transform
             result[attr.name] = list(attr.value)
     return result
 
+def _minimal_inputs(all_configs : List[List[List[str]]]) -> List[List[str]]:
+    """
+    Among all input configurations, find the minimal common subset(s) of attributes needed
+    for success invocation.
+    """
+    all_configs_sets = [ 
+        set(a) for tconfig in all_configs for a in tconfig
+    ]
+    
+    from itertools import chain, combinations
+    # universe of all columns
+    universe = set(chain.from_iterable(all_configs_sets))
+
+    # test subsets in increasing size
+    plausible = []
+    for r in range(1, len(universe) + 1):
+        for subset in combinations(universe, r):
+            subset = set(subset)
+            # Check if subset works for all objects
+            if all(any(set(schema).issubset(subset) for schema in obj) for obj in all_configs):
+                plausible.append(list(subset))
+    return plausible
 
 @runtime_checkable
 class HasTransformInputs(Protocol):

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -9,6 +9,20 @@ class TestInspect(BaseTestCase):
     def assertSortedEquals(self, arr1, arr2):
         self.assertEqual(sorted(arr1), sorted(arr2))
 
+    def assertInNoOrder(self, member, container):
+        container_set = [set(item) for item in container]
+        self.assertIn(set(member), container_set)     
+
+    def test_inspection_mincols(self):
+        op_input = [[['qid', 'docno']]]
+        sub_inputs = [
+            [['qid', 'docno', 'query']],
+            [['qid', 'docno', 'query']]
+        ]
+        plausible_configs = pt.inspect._minimal_inputs(op_input + sub_inputs)
+        self.assertInNoOrder(['qid', 'docno', 'query'], plausible_configs)
+
+
     def test_terrier_retriever(self):
         JIR = pt.java.autoclass('org.terrier.querying.IndexRef')
         indexref = JIR.of(self.here + "/fixtures/index/data.properties")

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -534,7 +534,29 @@ class TestOperators(BaseTestCase):
 
         # test using direct instantiation, as well as using the ** operator
         _test_expression(mock_input >> ptt.FeatureUnion(mock_f1, mock_f2))
-        _test_expression(mock_input >> mock_f1 ** mock_f2)       
+        _test_expression(mock_input >> mock_f1 ** mock_f2)  
+
+    def _assertInNoOrder(self, member, container):
+        container_set = [set(item) for item in container]
+        self.assertIn(set(member), container_set)     
+
+    def test_inspection_mincols(self):
+        op_input = [[['qid', 'docno']]]
+        sub_inputs = [
+            [['qid', 'docno', 'query']],
+            [['qid', 'docno', 'query']]
+        ]
+        from pyterrier._ops import NAryTransformerBase
+        plausible_configs = NAryTransformerBase._minimal_inputs(op_input + sub_inputs)
+        self._assertInNoOrder(['qid', 'docno', 'query'], plausible_configs)
+
+    def test_funion_inspection(self):
+        dataset = pt.get_dataset("vaswani")
+        index = dataset.get_index()
+        BM25 = pt.terrier.Retriever(index, wmodel="BM25")
+        pipe = (BM25 ** BM25)
+        self._assertInNoOrder(['qid', 'docno', 'query'], pt.inspect.transformer_inputs(pipe)) 
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -540,16 +540,6 @@ class TestOperators(BaseTestCase):
         container_set = [set(item) for item in container]
         self.assertIn(set(member), container_set)     
 
-    def test_inspection_mincols(self):
-        op_input = [[['qid', 'docno']]]
-        sub_inputs = [
-            [['qid', 'docno', 'query']],
-            [['qid', 'docno', 'query']]
-        ]
-        from pyterrier._ops import NAryTransformerBase
-        plausible_configs = NAryTransformerBase._minimal_inputs(op_input + sub_inputs)
-        self._assertInNoOrder(['qid', 'docno', 'query'], plausible_configs)
-
     def test_funion_inspection(self):
         dataset = pt.get_dataset("vaswani")
         index = dataset.get_index()


### PR DESCRIPTION
This PR ensures that transform_inputs identifies the minimum subset of columns that can work with a given feature union