### PR TITLE
Schematic docs can specify input cols

### DIFF
--- a/docs/extras/schematic.py
+++ b/docs/extras/schematic.py
@@ -41,7 +41,12 @@ class SchematicDirective(Directive):
         result = run_and_return_last(code, {'pt': pt}, {})
         if not isinstance(result, (dict, pt.Transformer)):
             return [self.state_machine.reporter.error(f"Expected dict or Transformer, got {result!r} (type: {type(result)})", line=self.lineno)]
-        html = pt.schematic.draw(result)
+        # parse any input columns supplied in the directive 
+        input_columns = self.options.get('input_columns')
+        if input_columns is not None:
+            input_columns = [x.strip() for x in input_columns.split(',')]
+
+        html = pt.schematic.draw(result, input_columns=input_columns)
         return [nodes.raw('', html, format='html')]
 
 

--- a/pyterrier/schematic.py
+++ b/pyterrier/schematic.py
@@ -125,7 +125,9 @@ def _get_schematic_css_js(container_id):
     return css, js
 
 
-def draw(transformer: Union[pt.Transformer, dict], *, outer_class: Optional[str] = None) -> str:
+def draw(transformer: Union[pt.Transformer, dict], *, 
+         outer_class: Optional[str] = None, 
+         input_columns: Optional[List[str]] = None) -> str:
     """Draws a transformer as an HTML schematic.
 
     If the transformer is already a ``SchematicDict``, it will be drawn directly.
@@ -134,15 +136,17 @@ def draw(transformer: Union[pt.Transformer, dict], *, outer_class: Optional[str]
 
     Args:
         transformer: The transformer to draw, or a dict in ``SchematicDict`` format.
+        input_columns: If you want to specify the input columns for the transformer (pipeline).
         outer_class: An optional CSS class to apply to the outer container of the schematic.
 
     Returns:
         An HTML string representing the schematic of the transformer.
     """
     if isinstance(transformer, dict):
+        assert input_columns is None, "Cannot set input_columns and provide a SchematicDict input."
         schematic = transformer
     else:
-        schematic = transformer_schematic(transformer)
+        schematic = transformer_schematic(transformer, input_columns=input_columns or _INFER)
     return draw_html_schematic(schematic, outer_class=outer_class)
 
 


### PR DESCRIPTION
This fixes an issue I noted in the terrier-retrieval.rst where the reranker was not being shown as such.

<img width="742" height="151" alt="image" src="https://github.com/user-attachments/assets/75e66dcf-81d7-4104-963f-e2f32591676b" />
