### PR TITLE
allow inspection of transformer without inspectable attributes

### DIFF
--- a/pyterrier/inspect.py
+++ b/pyterrier/inspect.py
@@ -282,7 +282,7 @@ class TransformerAttribute:
     def __init__(
         self,
         name: str,
-        value: Any = MISSING,
+        value: Any,
         init_default_value: Any = inspect.Parameter.empty,
         init_parameter_kind: Optional[inspect._ParameterKind] = None,
     ):

--- a/pyterrier/inspect.py
+++ b/pyterrier/inspect.py
@@ -282,7 +282,7 @@ class TransformerAttribute:
     def __init__(
         self,
         name: str,
-        value: Any,
+        value: Any = MISSING,
         init_default_value: Any = inspect.Parameter.empty,
         init_parameter_kind: Optional[inspect._ParameterKind] = None,
     ):
@@ -297,22 +297,24 @@ class TransformerAttribute:
     init_default_value: Any
     init_parameter_kind: Optional[inspect._ParameterKind]
 
+    MISSING = object()
 
-def transformer_attributes(transformer: pt.Transformer, strict=True) -> List[TransformerAttribute]:
+
+def transformer_attributes(transformer: pt.Transformer, *, strict: bool = True) -> List[TransformerAttribute]:
     """Infers a list of attributes of the transformer.
 
-    Here, an attribute is defined as any attribute of the transformer that is explicity set by the ``__init__`` method,
+    Here, an attribute is defined as any attribute of the transformer that is explicitly set by the ``__init__`` method,
     either under the same name (e.g., ``self.foo = foo``) or as a private attribute (e.g., ``self._foo = foo``).
 
-    This definition allow for a set of attributes that should describe the state of a transformer. These attributes can
+    This definition allows for a set of attributes that should describe the state of a transformer. These attributes can
     be used to reconstruct the transformer from its attributes, e.g., by calling :meth:`~pyterrier.inspect.transformer_apply_attributes`.
 
-    To handle edge cases (e.g., where the ``__init__`` paraemters do not match the attribute names), you can implement
+    To handle edge cases (e.g., where the ``__init__`` parameters do not match the attribute names), you can implement
     the :class:`~pyterrier.inspect.HasAttributes` protocol.
 
     Args:
         transformer: The transformer to inspect.
-        strict: If True, raises an error if an attribute cannot be identified from the transformer. If False, the attribute's value is set to ``...`` in these cases.
+        strict: If True, raises an error if an attribute cannot be identified from the transformer. If False, the attribute's value is set to ``TransformerAttribute.MISSING`` in these cases.
 
     Returns:
         A list of :class:`~pyterrier.inspect.TransformerAttribute` objects representing the attributes of the transformer.
@@ -335,7 +337,7 @@ def transformer_attributes(transformer: pt.Transformer, strict=True) -> List[Tra
             if strict:
                 raise InspectError(f"Cannot identify attribute {p.name} in transformer {transformer}. Ensure that the attribute is set in the __init__ method.")
             else:
-                val = ... # could not identify the attribute
+                val = TransformerAttribute.MISSING # could not identify the attribute
         result.append(TransformerAttribute(
             name=p.name,
             value=val,
@@ -377,6 +379,9 @@ def transformer_apply_attributes(transformer: pt.Transformer, **kwargs: Any) -> 
             attr.value = kwargs.pop(attr.name)
     if any(kwargs):
         raise InspectError(f"Unknown attributes {list(kwargs.keys())} for transformer {transformer}")
+    missing_attributes = [attr.name for attr in attributes if attr.value is TransformerAttribute.MISSING]
+    if missing_attributes:
+        raise InspectError(f"Attributes {missing_attributes} for transformer {transformer} are missing.")
     init_args = []
     init_kwargs = {}
     for attr in attributes:

--- a/pyterrier/inspect.py
+++ b/pyterrier/inspect.py
@@ -312,6 +312,7 @@ def transformer_attributes(transformer: pt.Transformer, strict=True) -> List[Tra
 
     Args:
         transformer: The transformer to inspect.
+        strict: If True, raises an error if an attribute cannot be identified from the transformer. If False, the attribute's value is set to ``...`` in these cases.
 
     Returns:
         A list of :class:`~pyterrier.inspect.TransformerAttribute` objects representing the attributes of the transformer.

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -366,7 +366,7 @@ class TestInspect(BaseTestCase):
         attrs = pt.inspect.transformer_attributes(A(1), strict=False)
         self.assertEqual(1, len(attrs))
         self.assertEqual('x', attrs[0].name)
-        self.assertEqual(..., attrs[0].value)
+        self.assertEqual(pt.inspect.TransformerAttribute.MISSING, attrs[0].value)
 
         self.assertEqual(0, len(pt.inspect.subtransformers(A(1))))
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -349,6 +349,27 @@ class TestInspect(BaseTestCase):
         with self.assertRaises(pt.inspect.InspectError):
             pt.inspect.transformer_outputs(br0 >> pt.apply.generic(_rename_context), ["qid", "query"])
 
+    def test_subtransformers_bad_attr_inspect(self):
+
+        # this class does not set self.x in __init__  
+        class A(pt.Transformer):
+            def __init__(self, x):
+                # x is ignored
+                super().__init__()
+
+            def transform(self, inp):
+                return None
+        
+        with self.assertRaises(pt.inspect.InspectError):
+            print(pt.inspect.transformer_attributes(A(1)))
+
+        attrs = pt.inspect.transformer_attributes(A(1), strict=False)
+        self.assertEqual(1, len(attrs))
+        self.assertEqual('x', attrs[0].name)
+        self.assertEqual(..., attrs[0].value)
+
+        self.assertEqual(0, len(pt.inspect.subtransformers(A(1))))
+
     def test_transformer_type(self):
         class A(pt.Transformer):
             def transform(self, inp):


### PR DESCRIPTION
Adds a strict kwarg for pt.inspect.transformer_attributes, and uses that in subtransformers. 