### PR TITLE
dont change dataframes in-place

### DIFF
--- a/pyterrier/terrier/retriever.py
+++ b/pyterrier/terrier/retriever.py
@@ -383,7 +383,7 @@ class Retriever(pt.Transformer):
         """
         results=[]
         if not isinstance(queries, pd.DataFrame):
-            raise ValueError(".transform() should be passed a dataframe. Use .search() to execute a single query; Use .transform_iter() for iter-dicts")
+            raise ValueError(".transform() should be passed a DataFrame (found %s). Use .search() to execute a single query; Use .transform_iter() for iter-dicts" % str(type(queries)))
         
         docno_provided = "docno" in queries.columns
         docid_provided = "docid" in queries.columns

--- a/pyterrier/text.py
+++ b/pyterrier/text.py
@@ -296,6 +296,8 @@ def snippets(
             docres[summary_attr]  = ""
             return docres
 
+        # dont assign new columns to an existing df
+        psgres = psgres.copy()
         psgres[["olddocno", "pid"]] = psgres.docno.str.split("%p", expand=True)
 
         newdf = psgres.groupby(['qid', 'olddocno'])[text_attr].agg(joinstr.join).reset_index().rename(columns={text_attr : summary_attr, 'olddocno' : 'docno'})


### PR DESCRIPTION
Closes #515 

In #515, we discussed ensuring the transformers dont make in-place edits of dataframes. One solution in that PR is to alter the DF to make it immutable. The code on StackOverflow produces warnings under Panda 2 (because it access df._data) so I dont think we can commit this permanently

I tested this in Compose:
```
    def transform(self, inp : pd.DataFrame) -> pd.DataFrame:
        IMMUTABLE = True
        from .immmutable_df import make_dataframe_immutable
        out = inp
        if IMMUTABLE and out is not None:
            make_dataframe_immutable(inp)
        for m in self._transformers:
            out = m.transform(out)
            if IMMUTABLE:
                make_dataframe_immutable(out)
        return out
```

I'll try to attach the immultable_df.py