### PR TITLE
Add SuiteEval to extensions

### DIFF
--- a/docs/extensions.txt
+++ b/docs/extensions.txt
@@ -18,5 +18,5 @@ pyterrier_pisa # PISA <https://github.com/terrierteam/pyterrier_pisa>
 pyterrier_rag # RAG <https://github.com/terrierteam/pyterrier_rag>
 # Sentence Transformers <https://github.com/soldni/pyterrier_sentence_transformers>
 # SPLADE <https://github.com/cmacdonald/pyt_splade>
-pyterrier_t5 # T5 <https://github.com/terrierteam/pyterrier_t5>
 suiteeval # SuiteEval <https://github.com/parryparry/suiteeval>
+pyterrier_t5 # T5 <https://github.com/terrierteam/pyterrier_t5>


### PR DESCRIPTION
SuiteEval is now on Pypi and documentation stubs have been produced. This PR adds SuiteEval to extensions.txt such that integrated documentation can be built.