### PR TITLE
Fix for #598 - ir_measures like NumQ dont aggregate well in pt.Experiment

### DIFF
--- a/pyterrier/_evaluation/_rendering.py
+++ b/pyterrier/_evaluation/_rendering.py
@@ -59,7 +59,7 @@ def _mean_of_measures(result, measures=None, num_q = None):
     for m in measures_remove:
         if m in measures:
             measures.remove(m)
-    measures_no_mean = set(["num_q", "num_rel", "num_ret", "num_rel_ret"])
+    measures_no_mean = set(["num_q", "num_rel", "num_ret", "num_rel_ret", "NumQ", "NumRel", "NumRet", "NumRelRet"])
     for val in result.values():
         for measure in measures:
             measure_val = val[measure]

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -360,13 +360,15 @@ class TestExperiment(TempDirTestCase):
         self.assertEqual(measures.iloc[1]["map -"], 0)
 
     def test_one_row(self):
+        from pyterrier.measures import NumQ
         vaswani = pt.datasets.get_dataset("vaswani")
         br = pt.terrier.Retriever(self._vaswani_index(), wmodel='BM25')
         rtr = pt.Experiment([br], vaswani.get_topics().head(10), vaswani.get_qrels(), ["map", "ndcg", "num_q"])
         self.assertEqual(10, rtr.iloc[0]["num_q"])
-        
-        rtr = pt.Experiment([br], vaswani.get_topics().head(10), vaswani.get_qrels(), ["map", "ndcg"], dataframe=False)
 
+        rtr = pt.Experiment([br], vaswani.get_topics().head(10), vaswani.get_qrels(), [NumQ])
+        self.assertEqual(10, rtr.iloc[0]["NumQ"])
+        
     def test_one_row_round(self):
         import pyterrier as pt
         vaswani = pt.datasets.get_dataset("vaswani")


### PR DESCRIPTION
Closes: #598 

This is a hotfix - I think there is probably a more robust way of doing this by keeping the ir_m aggregators for each measure, but I want to prioritise other improvements to pt.Experiment