### PR TITLE
Revise experiment pipeline message

### DIFF
--- a/docs/troubleshooting/inspection.rst
+++ b/docs/troubleshooting/inspection.rst
@@ -11,8 +11,11 @@ There are two possibilities:
 
 .. code-block:: none
 
-    /pyterrier/_evaluation/_validation.py:41: UserWarning: "Transformer XXX (AA) at position Z
-    does not produce all required columns ZZ, found only AA.
+    /pyterrier/_evaluation/_validation.py:41: UserWarning: "Experiment Pipeline Validation Report
+
+    The following pipelines failed validation (i.e., they are incompatible with one another or the provided topics):
+     - Pipeline #X: XXX
+
 
 This suggests a mistake in your pipeline formulation - e.g. you are passing a Q dataframe of queries, when
 ranked results (R) are expected. Such pipelines will typically produce an error when the experiment is
@@ -22,10 +25,11 @@ executed.
 
 .. code-block:: none
 
-    /pyterrier/_evaluation/_validation.py:41: UserWarning: Transformer XXX ((AA >> BB)) at 
-    position Z failed to validate: Cannot determine outputs for (AA >> BB) with inputs: 
-    ['qid', 'query'] - if your pipeline works, set validate='ignore'  to remove this warning,
-    or add transform_output method to the transformers in this pipeline to clarify how it works
+    /pyterrier/_evaluation/_validation.py:41: UserWarning: Experiment Pipeline Validation Report
+
+    The following pipelines could not be validated (i.e., it is unclear what outputs they produce):
+     - Pipeline #X: XXX
+    If these pipelines work, set validate='ignore' to remove this warning, or make them inspectable to clarify how they work.
 
 In both cases, if you are sure your pipeline works, as the warning suggests, you can set `validate='ignore'` 
 kwarg when calling ``pt.Experiment``::

--- a/pyterrier/_evaluation/_validation.py
+++ b/pyterrier/_evaluation/_validation.py
@@ -66,7 +66,7 @@ def _validate(
             message += 'The following pipelines could not be validated (i.e., it is unclear what outputs they produce):'
             for p in validation_failed_pipelines:
                 message += f'\n - {p}'
-            message += "\nIf these pipelines work, set validate='ignore' to remove this warning, or add transform_output method to the transformers in this pipeline to clarify how it works\n\n"
+            message += "\nIf these pipelines work, set validate='ignore' to remove this warning, or make them inspectable to clarify how they work.\n\n"
 
         message += 'See https://pyterrier.readthedocs.io/en/latest/troubleshooting/inspection.html for more information.'
 


### PR DESCRIPTION
@Parry-Parry does this help clarify what's going on?

I think the whitespace helps parse when there's long pipelines in the middle.

Failure:

```
UserWarning: Experiment Pipeline Validation Report

The following pipelines failed validation (i.e., they are incompatible with one another or the provided topics):
 - Pipeline #0: QueryExpansion([/Users/sean.macavaney/.pyterrier/artifacts/23d244189d7f6c5c9cfa333be3ec48808f8df7d6d45ed920fdd58195abda0f62/data.properties](http://localhost:8888/Users/sean.macavaney/.pyterrier/artifacts/23d244189d7f6c5c9cfa333be3ec48808f8df7d6d45ed920fdd58195abda0f62/data.properties),3,10,<org.terrier.querying.RM3 at 0x135a14ea0 jclass=org[/terrier/querying/RM3](http://localhost:8888/terrier/querying/RM3) jself=<LocalRef obj=0x328b7e44a at 0x3392d3610>>)

See https://pyterrier.readthedocs.io/en/latest/troubleshooting/inspection.html for more information.
  warn(message)
```

 Not inspectable:

```
UserWarning: Experiment Pipeline Validation Report

The following pipelines could not be validated (i.e., it is unclear what outputs they produce):
 - Pipeline #0: <__main__.X object at 0x33ed477f0>
If these pipelines work, set validate='ignore' to remove this warning, or make them inspectable to clarify how they work.

See https://pyterrier.readthedocs.io/en/latest/troubleshooting/inspection.html for more information.
  warn(message)
```