### PR TITLE
Adding Colab Badge in schematics-demo.ipynb

### DIFF
--- a/examples/notebooks/schematics-demo.ipynb
+++ b/examples/notebooks/schematics-demo.ipynb
@@ -5,7 +5,7 @@
    "id": "3ec67219",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](schematics-demo.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/terrier-org/pyterrier/blob/master/examples/notebooks/schematics-demo.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
This pull request makes minor updates to the `schematics-demo.ipynb` notebook, primarily to improve usability and compatibility. The most notable change is the addition of a Colab badge for easier access, along with updates to the notebook's metadata to reflect a more standard Python environment.

Usability improvements:

* Added a Colab badge at the top of the notebook to allow users to easily open and run the notebook in Google Colab.