### PR TITLE
Add context in the form of the calling Transformer to pt.validate error message

### DIFF
--- a/pyterrier/__init__.py
+++ b/pyterrier/__init__.py
@@ -4,8 +4,9 @@ __version__ = '1.0.4'
 from typing import Any
 from deprecated import deprecated
 
-from pyterrier import model, utils, validate, testing
+from pyterrier import model, utils, testing
 from pyterrier.transformer import Transformer, Estimator, Indexer
+from pyterrier import validate
 from pyterrier._ops import RankCutoff, Compose
 from pyterrier._artifact import Artifact
 

--- a/pyterrier/_ops.py
+++ b/pyterrier/_ops.py
@@ -232,7 +232,7 @@ class FeatureUnion(NAryTransformerBase):
         ])
 
     def transform(self, inputRes):
-        pt.validate.result_frame(inputRes)
+        pt.validate.result_frame(inputRes, context=self)
 
         num_results = len(inputRes)
         import numpy as np

--- a/pyterrier/apply_base.py
+++ b/pyterrier/apply_base.py
@@ -29,7 +29,7 @@ class DropColumnTransformer(pt.Transformer):
         Returns:
             The input DataFrame with the column dropped.
         """
-        pt.validate.columns(inp, includes=[self.col])
+        pt.validate.columns(inp, includes=[self.col], context=self)
         return inp.drop(columns=[self.col])
 
     def transform_iter(self, inp: pt.model.IterDict) -> pt.model.IterDict:
@@ -43,7 +43,7 @@ class DropColumnTransformer(pt.Transformer):
             The input with the column dropped.
         """
         inp = pt.utils.peekable(inp)
-        pt.validate.columns_iter(inp, includes=[self.col])
+        pt.validate.columns_iter(inp, includes=[self.col], context=self)
         for rec in inp:
             new_rec = rec.copy()
             new_rec.pop(self.col, None) # None ensures no error if key doesn't exist
@@ -76,7 +76,7 @@ class RenameColumnsTransformer(pt.Transformer):
             The input DataFrame with the column dropped.
         """
         if self.errors == 'raise':
-            pt.validate.columns(inp, includes=list(self.columns.keys()))
+            pt.validate.columns(inp, includes=list(self.columns.keys()), context=self)
         return inp.rename(columns=self.columns, errors=self.errors)
 
     def __repr__(self):
@@ -123,7 +123,7 @@ class ApplyByRowTransformer(pt.Transformer):
             The input DataFrame with the new values assign to ``col``
         """
         if self.required_columns is not None:
-            pt.validate.columns(inp, includes=self.required_columns)
+            pt.validate.columns(inp, includes=self.required_columns, context=self)
 
         if self.batch_size is None:
             return self._apply_df(inp)
@@ -185,7 +185,7 @@ class ApplyForEachQuery(pt.Transformer):
 
     def transform(self, res: pd.DataFrame) -> pd.DataFrame:
         if self.required_columns is not None:
-            pt.validate.columns(res, includes=self.required_columns)
+            pt.validate.columns(res, includes=self.required_columns, context=self)
 
         if len(res) == 0:
             return self.fn(res)
@@ -249,7 +249,7 @@ class ApplyIterForEachQuery(pt.Transformer):
     def transform_iter(self, inp: pt.model.IterDict) -> pt.model.IterDict:
         if self.required_columns is not None:
             inp = pt.utils.peekable(inp)
-            pt.validate.columns_iter(inp, includes=self.required_columns)
+            pt.validate.columns_iter(inp, includes=self.required_columns, context=self)
 
         if self.verbose:
             inp = pt.tqdm(inp, desc="pt.apply.by_query()")
@@ -326,7 +326,7 @@ class ApplyDocumentScoringTransformer(pt.Transformer):
 
     def transform(self, inp: pd.DataFrame) -> pd.DataFrame:
         if self.required_columns is not None:
-            pt.validate.columns(inp, includes=self.required_columns)
+            pt.validate.columns(inp, includes=self.required_columns, context=self)
 
         outputRes = inp.copy()
         if len(outputRes) == 0:
@@ -381,7 +381,7 @@ class ApplyDocFeatureTransformer(pt.Transformer):
     def transform_iter(self, inp: pt.model.IterDict) -> pt.model.IterDict:
         if self.required_columns is not None:
             inp = pt.utils.peekable(inp)
-            pt.validate.columns_iter(inp, includes=self.required_columns)
+            pt.validate.columns_iter(inp, includes=self.required_columns, context=self)
 
         # we assume that the function can take a dictionary as well as a pandas.Series. As long as [""] notation is used
         # to access fields, both should work
@@ -393,7 +393,7 @@ class ApplyDocFeatureTransformer(pt.Transformer):
 
     def transform(self, inp: pd.DataFrame) -> pd.DataFrame:
         if self.required_columns is not None:
-            pt.validate.columns(inp, includes=self.required_columns)
+            pt.validate.columns(inp, includes=self.required_columns, context=self)
 
         fn = self.fn
         outputRes = inp.copy()
@@ -446,7 +446,7 @@ class ApplyQueryTransformer(pt.Transformer):
     def transform_iter(self, inp: pt.model.IterDict) -> pt.model.IterDict:
         if self.required_columns is not None:
             inp = pt.utils.peekable(inp)
-            pt.validate.columns_iter(inp, includes=self.required_columns)
+            pt.validate.columns_iter(inp, includes=self.required_columns, context=self)
 
         # we assume that the function can take a dictionary as well as a pandas.Series. As long as [""] notation is used
         # to access fields, both should work
@@ -461,7 +461,7 @@ class ApplyQueryTransformer(pt.Transformer):
 
     def transform(self, inp: pd.DataFrame) -> pd.DataFrame:  
         if self.required_columns is not None:
-            pt.validate.columns(inp, includes=self.required_columns)
+            pt.validate.columns(inp, includes=self.required_columns, context=self)
 
         if "query" in inp.columns:
             # we only push if a query already exists
@@ -532,7 +532,7 @@ class ApplyGenericTransformer(pt.Transformer):
 
     def transform(self, inp: pd.DataFrame) -> pd.DataFrame:
         if self.required_columns is not None:
-            pt.validate.columns(inp, includes=self.required_columns)
+            pt.validate.columns(inp, includes=self.required_columns, context=self)
 
         # no batching
         if self.batch_size is None:
@@ -580,7 +580,7 @@ class ApplyGenericIterTransformer(pt.Transformer):
     def transform_iter(self, inp: pt.model.IterDict) -> pt.model.IterDict:
         if self.required_columns is not None:
             inp = pt.utils.peekable(inp)
-            pt.validate.columns_iter(inp, includes=self.required_columns)
+            pt.validate.columns_iter(inp, includes=self.required_columns, context=self)
 
         if self.batch_size is None:
             # no batching

--- a/pyterrier/ltr.py
+++ b/pyterrier/ltr.py
@@ -15,7 +15,7 @@ class AblateFeatures(Transformer):
         self.null = 0
         
     def transform(self, topics_and_res):
-        pt.validate.result_frame(topics_and_res, extra_columns=["features"])
+        pt.validate.result_frame(topics_and_res, extra_columns=["features"], context=self)
         if len(topics_and_res) == 0:
             return topics_and_res
         
@@ -37,7 +37,7 @@ class KeepFeatures(Transformer):
         
     def transform(self, topics_and_res):
         
-        pt.validate.result_frame(topics_and_res, extra_columns=["features"])
+        pt.validate.result_frame(topics_and_res, extra_columns=["features"], context=self)
 
         if len(topics_and_res) == 0:
             return topics_and_res
@@ -70,7 +70,7 @@ class RegressionTransformer(Estimator):
         Args:
             topicsTrain(DataFrame): A dataframe with the topics to train the model
         """
-        pt.validate.result_frame(topics_and_results_Train, extra_columns=["features"])
+        pt.validate.result_frame(topics_and_results_Train, extra_columns=["features"], context=self)
         if len(topics_and_results_Train) == 0:
             raise ValueError("No topics to fit to")
         train_DF = topics_and_results_Train.merge(qrelsTrain, on=['qid', 'docno'], how='left').fillna(0)
@@ -86,7 +86,7 @@ class RegressionTransformer(Estimator):
         Args:
             topicsTest(DataFrame): A dataframe with the test topics.
         """
-        pt.validate.result_frame(test_DF, extra_columns=["features"])
+        pt.validate.result_frame(test_DF, extra_columns=["features"], context=self)
         test_DF = test_DF.copy()
 
         # check for change in number of features
@@ -143,8 +143,8 @@ class LTRTransformer(RegressionTransformer):
         if topics_and_results_Valid is None or len(topics_and_results_Valid) == 0:
             raise ValueError("No validation results to fit to")
 
-        pt.validate.result_frame(topics_and_results_Train, extra_columns=["features"])
-        pt.validate.result_frame(topics_and_results_Valid, extra_columns=["features"])
+        pt.validate.result_frame(topics_and_results_Train, extra_columns=["features"], context=self)
+        pt.validate.result_frame(topics_and_results_Valid, extra_columns=["features"], context=self)
 
         tr_res = topics_and_results_Train.merge(qrelsTrain, on=['qid', 'docno'], how='left').fillna(0)
         va_res = topics_and_results_Valid.merge(qrelsValid, on=['qid', 'docno'], how='left').fillna(0)
@@ -197,7 +197,7 @@ class FastRankEstimator(Estimator):
 
     def fit(self, topics_and_results_Train, qrelsTrain, topics_and_results_Valid=None, qrelsValid=None):
 
-        pt.validate.result_frame(topics_and_results_Train, extra_columns=["features"])
+        pt.validate.result_frame(topics_and_results_Train, extra_columns=["features"], context=self)
 
         if topics_and_results_Train is None or len(topics_and_results_Train) == 0:
             raise ValueError("No training results to fit to")
@@ -213,7 +213,7 @@ class FastRankEstimator(Estimator):
 
         :param topics_and_docs_Test: A dataframe with the test topics.
         """
-        pt.validate.result_frame(topics_and_docs_Test, extra_columns=["features"])
+        pt.validate.result_frame(topics_and_docs_Test, extra_columns=["features"], context=self)
         if self.model is None:
             raise ValueError("fit() must be called first")
         test_DF = topics_and_docs_Test.copy()

--- a/pyterrier/terrier/retriever.py
+++ b/pyterrier/terrier/retriever.py
@@ -420,7 +420,7 @@ class Retriever(pt.Transformer):
             raise ValueError(".transform() should be passed a DataFrame (found %s). Use .search() to execute a single query; Use .transform_iter() for iter-dicts" % str(type(queries)))
         
         # use pt.validate - this makes inspection of input columns better
-        with pt.validate.any(queries) as v:
+        with pt.validate.any(queries, context=self) as v:
             v.columns(includes=['qid', 'query'], excludes=['docid', 'docno'], mode='retrieve') # query based frame without docno or docid
             v.columns(includes=['qid', 'query', 'docid'], mode='rerank') # docid-based results frame
             v.query_frame(extra_columns=['query_toks'], mode='retrieve_toks')
@@ -609,7 +609,7 @@ class TextIndexProcessor(pt.Transformer):
         # we use _IterDictIndexer_nofifo, as _IterDictIndexer_fifo (which is default on unix) doesnt support IndexingType.MEMORY as a destination
         from pyterrier.terrier import IndexFactory
         from pyterrier.terrier.index import IndexingType, _IterDictIndexer_nofifo
-        pt.validate.result_frame(topics_and_res, extra_columns=[self.body_attr, 'query'])
+        pt.validate.result_frame(topics_and_res, extra_columns=[self.body_attr, 'query'], context=self)
         documents = topics_and_res[["docno", self.body_attr]].drop_duplicates(subset="docno").rename(columns={self.body_attr:'text'})
         indexref = _IterDictIndexer_nofifo(
             None, 
@@ -843,7 +843,7 @@ class FeaturesRetriever(Retriever):
             raise ValueError(".transform() should be passed a dataframe. Use .search() to execute a single query; Use .transform_iter() for iter-dicts")
 
         # use pt.validate - this makes inspection of input columns better
-        with pt.validate.any(queries) as v:
+        with pt.validate.any(queries, context=self) as v:
             v.columns(includes=['qid', 'query', 'docid', 'score'], mode='rerank') # docid-based results frame, with scores (features column is added, so we need input scores)
             v.query_frame(extra_columns=['query_toks'], mode='retrieve_toks')
             v.query_frame(extra_columns=['query'], mode='retrieve')

--- a/pyterrier/terrier/rewrite.py
+++ b/pyterrier/terrier/rewrite.py
@@ -302,7 +302,7 @@ class QueryExpansion(pt.Transformer):
         rq.setControl("qe_fb_terms", str(self.fb_terms))
 
     def transform(self, topics_and_res):
-        with pt.validate.any(topics_and_res) as v:
+        with pt.validate.any(topics_and_res, context=self) as v:
             v.columns(includes=['qid', 'docno', 'query'])
             v.columns(includes=['qid', 'docid', 'query'])
         from .retriever import _query_needs_tokenised

--- a/pyterrier/text.py
+++ b/pyterrier/text.py
@@ -315,7 +315,7 @@ class DePassager(pt.Transformer):
         self.agg = agg
 
     def transform(self, topics_and_res):
-        pt.validate.columns(topics_and_res, includes=['qid', 'docno'] + (['score'] if self.agg != 'first' else []))
+        pt.validate.columns(topics_and_res, includes=['qid', 'docno'] + (['score'] if self.agg != 'first' else []), context=self)
         topics_and_res = topics_and_res.copy()
         topics_and_res[["olddocno", "pid"]] = topics_and_res.docno.str.split("%p", expand=True) if len(topics_and_res) > 0 else pd.DataFrame(columns=["olddocno", "pid"])
         if self.agg == 'max':
@@ -400,7 +400,7 @@ class SlidingWindowPassager(pt.Transformer):
             self.detokenize = ' '.join
 
     def transform(self, topics_and_res):
-        with pt.validate.any(topics_and_res) as v:
+        with pt.validate.any(topics_and_res, context=self) as v:
             cols = [self.text_attr] + ([self.title_attr] if self.prepend_title else [])
             v.result_frame(cols)
             v.document_frame(cols)

--- a/pyterrier/validate.py
+++ b/pyterrier/validate.py
@@ -53,7 +53,8 @@ def columns(
     *,
     includes: Optional[List[str]] = None,
     excludes: Optional[List[str]] = None,
-    warn: bool = False
+    warn: bool = False, 
+    context : Optional[pt.Transformer] = None
 ) -> None:
     """Check that the input frame has the expected columns.
 
@@ -62,6 +63,7 @@ def columns(
         includes: List of required columns
         excludes: List of forbidden columns
         warn: If True, raise warnings instead of exceptions for validation errors
+        context: The transformer context for error messages
 
     Raises:
         InputValidationError: If warn=False and validation fails
@@ -70,7 +72,7 @@ def columns(
     .. versionchanged:: 0.15.0
         Accept ``List[str]`` inp columns
     """
-    with any(inp, warn=warn) as v:
+    with any(inp, warn=warn, context=context) as v:
         v.columns(includes=includes, excludes=excludes)
 
 
@@ -203,8 +205,8 @@ def document_iter(inp: 'pt.utils.PeekableIter', extra_columns: Optional[List[str
         InputValidationError: If warn=False and validation fails
         InputValidationWarning: If warn=True and validation fails
     """
-    with any_iter(inp, warn=warn) as v:
-        v.document_iter(extra_columns, context=context)
+    with any_iter(inp, warn=warn, context=context) as v:
+        v.document_iter(extra_columns)
 
 
 def any(inp: Union[pd.DataFrame, List[str]], warn: bool = False, context : Optional[pt.Transformer] = None) -> '_ValidationContextManager':
@@ -261,7 +263,7 @@ class _ValidationContextManager:
             return False # the captured exception takes priority
 
         if self.attempts > 0 and self.attempts == len(self.errors):
-            context_str -= f" in transformer {str(self.context)}" if self.context is not None else ""
+            context_str = f" in transformer {str(self.context)}" if self.context is not None else ""
             message = "DataFrame(columns=%s) %s does not match required columns for this transformer." % (str(self.inp_columns), context_str)
             if self.warn:
                 warnings.warn(f"{message} {self.errors}", InputValidationWarning)
@@ -339,8 +341,8 @@ class _IterValidationContextManager:
             return False # the captured exception takes priority
 
         if self.attempts > 0 and self.attempts == len(self.errors):
-            context_str -= f"in transformer {str(self.context)}" if self.context is not None else "for this transformer"
-            message = "Input does not match required columns %." % context_str
+            context_str = f"in transformer {str(self.context)}" if self.context is not None else "for this transformer"
+            message = "Input does not match required columns %s." % context_str
             if self.warn:
                 warnings.warn(f"{message} {self.errors}", InputValidationWarning)
             else:

--- a/pyterrier/validate.py
+++ b/pyterrier/validate.py
@@ -74,13 +74,14 @@ def columns(
         v.columns(includes=includes, excludes=excludes)
 
 
-def query_frame(inp: Union[pd.DataFrame, List[str]], extra_columns: Optional[List[str]] = None, warn: bool = False) -> None:
+def query_frame(inp: Union[pd.DataFrame, List[str]], extra_columns: Optional[List[str]] = None, warn: bool = False, context : Optional[pt.Transformer] = None) -> None:
     """Check that the input frame is a valid query frame.
 
     Args:
         inp: Input DataFrame or columns to validate
         extra_columns: Additional required columns
         warn: If True, raise warnings instead of exceptions for validation errors
+        context: The transformer context for error messages
 
     Raises:
         InputValidationError: If warn=False and validation fails
@@ -89,17 +90,18 @@ def query_frame(inp: Union[pd.DataFrame, List[str]], extra_columns: Optional[Lis
     .. versionchanged:: 0.15.0
         Accept ``List[str]`` inp columns
     """
-    with any(inp, warn=warn) as v:
+    with any(inp, warn=warn, context=context) as v:
         v.query_frame(extra_columns)
 
 
-def result_frame(inp: Union[pd.DataFrame, List[str]], extra_columns: Optional[List[str]] = None, warn: bool = False) -> None:
+def result_frame(inp: Union[pd.DataFrame, List[str]], extra_columns: Optional[List[str]] = None, warn: bool = False, context : Optional[pt.Transformer] = None) -> None:
     """Check that the input frame is a valid result frame.
 
     Args:
         inp: Input DataFrame or columns to validate
         extra_columns: Additional required columns
         warn: If True, raise warnings instead of exceptions for validation errors
+        context: The transformer context for error messages
 
     Raises:
         InputValidationError: If warn=False and validation fails
@@ -108,17 +110,18 @@ def result_frame(inp: Union[pd.DataFrame, List[str]], extra_columns: Optional[Li
     .. versionchanged:: 0.15.0
         Accept ``List[str]`` inp columns
     """
-    with any(inp, warn=warn) as v:
+    with any(inp, warn=warn, context=context) as v:
         v.result_frame(extra_columns)
 
 
-def document_frame(inp: Union[pd.DataFrame, List[str]], extra_columns: Optional[List[str]] = None, warn: bool = False) -> None:
+def document_frame(inp: Union[pd.DataFrame, List[str]], extra_columns: Optional[List[str]] = None, warn: bool = False, context : Optional[pt.Transformer] = None) -> None:
     """Check that the input frame is a valid document frame.
 
     Args:
         inp: Input DataFrame or columns to validate
         extra_columns: Additional required columns
         warn: If True, raise warnings instead of exceptions for validation errors
+        context: The transformer context for error messages
 
     Raises:
         InputValidationError: If warn=False and validation fails
@@ -127,7 +130,7 @@ def document_frame(inp: Union[pd.DataFrame, List[str]], extra_columns: Optional[
     .. versionchanged:: 0.15.0
         Accept ``List[str]`` inp columns
     """
-    with any(inp, warn=warn) as v:
+    with any(inp, warn=warn, context=context) as v:
         v.document_frame(extra_columns)
 
 
@@ -136,7 +139,8 @@ def columns_iter(
     *,
     includes: Optional[List[str]] = None,
     excludes: Optional[List[str]] = None,
-    warn: bool = False
+    warn: bool = False,
+    context : Optional[pt.Transformer] = None
 ) -> None:
     """Check that the input frame has the expected columns.
 
@@ -145,92 +149,99 @@ def columns_iter(
         includes: List of required columns
         excludes: List of forbidden columns
         warn: If True, raise warnings instead of exceptions for validation errors
+        context: The transformer context for error messages
 
     Raises:
         InputValidationError: If warn=False and validation fails
         InputValidationWarning: If warn=True and validation fails
     """
-    with any_iter(inp, warn=warn) as v:
+    with any_iter(inp, warn=warn, context=context) as v:
         v.columns(includes=includes, excludes=excludes)
 
 
-def query_iter(inp: 'pt.utils.PeekableIter', extra_columns: Optional[List[str]] = None, warn: bool = False) -> None:
+def query_iter(inp: 'pt.utils.PeekableIter', extra_columns: Optional[List[str]] = None, warn: bool = False, context : Optional[pt.Transformer] = None) -> None:
     """Check that the input iterator is a valid query iterator.
 
     Args:
         inp: Input iterator to validate
         extra_columns: Additional required columns
         warn: If True, raise warnings instead of exceptions for validation errors
+        context: The transformer context for error messages
     Raises:
         InputValidationError: If warn=False and validation fails
         InputValidationWarning: If warn=True and validation fails
     """
-    with any_iter(inp, warn=warn) as v:
+    with any_iter(inp, warn=warn, context=context) as v:
         v.query_iter(extra_columns)
 
 
-def result_iter(inp: 'pt.utils.PeekableIter', extra_columns: Optional[List[str]] = None, warn: bool = False) -> None:
+def result_iter(inp: 'pt.utils.PeekableIter', extra_columns: Optional[List[str]] = None, warn: bool = False, context : Optional[pt.Transformer] = None) -> None:
     """Check that the input iterator is a valid result iterator.
 
     Args:
         inp: Input iterator to validate
         extra_columns: Additional required columns
         warn: If True, raise warnings instead of exceptions for validation errors
+        context: The transformer context for error messages
     Raises:
         InputValidationError: If warn=False and validation fails
         InputValidationWarning: If warn=True and validation fails
     """
-    with any_iter(inp, warn=warn) as v:
+    with any_iter(inp, warn=warn, context=context) as v:
         v.result_iter(extra_columns)
 
 
-def document_iter(inp: 'pt.utils.PeekableIter', extra_columns: Optional[List[str]] = None, warn: bool = False) -> None:
+def document_iter(inp: 'pt.utils.PeekableIter', extra_columns: Optional[List[str]] = None, warn: bool = False, context : Optional[pt.Transformer] = None) -> None:
     """Check that the input iterator is a valid document iterator.
 
     Args:
         inp: Input iterator to validate
         extra_columns: Additional required columns
         warn: If True, raise warnings instead of exceptions for validation errors
+        context: The transformer context for error messages
     Raises:
         InputValidationError: If warn=False and validation fails
         InputValidationWarning: If warn=True and validation fails
     """
     with any_iter(inp, warn=warn) as v:
-        v.document_iter(extra_columns)
+        v.document_iter(extra_columns, context=context)
 
 
-def any(inp: Union[pd.DataFrame, List[str]], warn: bool = False) -> '_ValidationContextManager':
+def any(inp: Union[pd.DataFrame, List[str]], warn: bool = False, context : Optional[pt.Transformer] = None) -> '_ValidationContextManager':
     """Create a validation context manager for a DataFrame or list of columns to test multiple possible modes.
 
     Args:
         inp: Input DataFrame or list of columns to validate
         warn: If True, raise warnings instead of exceptions for validation errors
+        context: The transformer for which to validate input, used for more informative error messages. This is optional, but recommended when validating inside a transformer.
     """
-    return _ValidationContextManager(inp, warn=warn)
+    return _ValidationContextManager(inp, warn=warn, context=context)
 
 
-def any_iter(inp: 'pt.utils.PeekableIter', warn: bool = False) -> '_IterValidationContextManager':
+def any_iter(inp: 'pt.utils.PeekableIter', warn: bool = False, context : Optional[pt.Transformer] = None) -> '_IterValidationContextManager':
     """Create a validation context manager for an iterator to test multiple possible modes.
 
     Args:
         inp: Input iterator to validate
         warn: If True, raise warnings instead of exceptions for validation errors
+        context: The transformer for which to validate input, used for more informative error messages. This is optional, but recommended when validating inside a transformer.
     """
     if not isinstance(inp, pt.utils.PeekableIter):
         raise AttributeError('inp is not peekable. Run the following before calling this function.\n'
                              'inp = pt.utils.peekable(inp) # !! IMPORTANT: you must re-assign the input to peekable '
                              '(not just pass it in), otherwise you will skip the first record !!')
-    return _IterValidationContextManager(inp, warn=warn)
+    return _IterValidationContextManager(inp, warn=warn, context=context)
 
 
 class _ValidationContextManager:
     """Context manager for validating the input to transformers."""
-    def __init__(self, inp: Union[pd.DataFrame, List[str]], warn: bool = False):
+    def __init__(self, inp: Union[pd.DataFrame, List[str]], warn: bool = False, context: Optional[pt.Transformer] = None):
         """Create a ValidationContextManager for the given DataFrame."""
         if isinstance(inp, pd.DataFrame):
             self.inp_columns = list(inp.columns)
         else:
             self.inp_columns = inp
+        self.context = context
         self.mode: Optional[str] = None
         self.attempts = 0
         self.errors: List[_TransformerMode] = []
@@ -250,7 +261,8 @@ class _ValidationContextManager:
             return False # the captured exception takes priority
 
         if self.attempts > 0 and self.attempts == len(self.errors):
-            message = "DataFrame(columns=%s) does not match required columns for this transformer." % str(self.inp_columns)
+            context_str -= f" in transformer {str(self.context)}" if self.context is not None else ""
+            message = "DataFrame(columns=%s) %s does not match required columns for this transformer." % (str(self.inp_columns), context_str)
             if self.warn:
                 warnings.warn(f"{message} {self.errors}", InputValidationWarning)
             else:
@@ -301,12 +313,13 @@ class _ValidationContextManager:
 _EMPTY_ITER = object()
 
 class _IterValidationContextManager:
-    def __init__(self, inp: 'pt.utils.PeekableIter', warn: bool = False):
+    def __init__(self, inp: 'pt.utils.PeekableIter', warn: bool = False, context: Optional[pt.Transformer] = None):
         self.sample_cols: Union[Set[str], object]
         try:
             self.sample_cols = set(inp.peek().keys())
         except StopIteration:
             self.sample_cols = _EMPTY_ITER
+        self.context = context
         self.mode: Optional[str] = None
         self.attempts = 0
         self.errors: List[_TransformerMode] = []
@@ -326,7 +339,8 @@ class _IterValidationContextManager:
             return False # the captured exception takes priority
 
         if self.attempts > 0 and self.attempts == len(self.errors):
-            message = "Input does not match required columns for this transformer."
+            context_str -= f"in transformer {str(self.context)}" if self.context is not None else "for this transformer"
+            message = "Input does not match required columns %." % context_str
             if self.warn:
                 warnings.warn(f"{message} {self.errors}", InputValidationWarning)
             else:


### PR DESCRIPTION
This PR adds a context kwarg to all of the validation - this allows the calling code to provide context to the error message, which can be useful to non-experienced readers seeing an InputValidationError

closes: #632 