### PR TITLE
prevent Index being loaded twice by Terrier artifact interface

### DIFF
--- a/pyterrier/terrier/index_factory.py
+++ b/pyterrier/terrier/index_factory.py
@@ -92,6 +92,22 @@ class IndexFactory:
         # dont allow the index properties to be rewritten
         pindex.dirtyProperties = False
         return index
+    
+    @staticmethod
+    def isLoaded(indexref) -> bool:
+        """
+        Returns true if the index is already loaded in memory, false otherwise.
+        Calls the underlying Terrier `IndexFactory.isLoaded() <http://terrier.org/docs/current/javadoc/org/terrier/structures/IndexFactory.html#isLoaded-org.terrier.querying.IndexRef->`_ method.
+        """
+        return pt.terrier.J.IndexFactory.isLoaded(indexref)
+    
+    @staticmethod
+    def isLocal(indexref) -> bool:
+        """
+        Returns true if the index is local, false otherwise.
+        Calls the underlying Terrier `IndexFactory.isLocal() <http://terrier.org/docs/current/javadoc/org/terrier/structures/IndexFactory.html#isLocal-org.terrier.querying.IndexRef->`_ method.
+        """
+        return pt.terrier.J.IndexFactory.isLocal(indexref)
 
     @staticmethod 
     def of(indexlike, memory : Union[bool, List[str]] = False):

--- a/pyterrier/terrier/retriever.py
+++ b/pyterrier/terrier/retriever.py
@@ -98,12 +98,20 @@ def _parse_index_like(index_location):
     JIR = pt.java.autoclass('org.terrier.querying.IndexRef')
     JI = pt.java.autoclass('org.terrier.structures.Index')
     from pyterrier.terrier import TerrierIndexer
-
     if isinstance(index_location, pt.terrier.TerrierIndex):
-        return index_location.index_ref()
+        from pyterrier.terrier.index_factory import IndexFactory
+        indexref = index_location.index_ref()
+        # if the index is local, load it and then replace the indexref
+        # with one that has a direct reference to the index, this will 
+        # prevent the index from being reloaded multiple times
+        if IndexFactory.isLocal(indexref):
+            indexref = index_location.index_obj().getIndexRef()
+            index_location._index_ref = indexref
+        return indexref
     if isinstance(index_location, JIR):
         return index_location
     if isinstance(index_location, JI):
+        # this new indexref will be a directindexref, so index will not be reloaded 
         return pt.java.cast('org.terrier.structures.Index', index_location).getIndexRef()
     if isinstance(index_location, str) or issubclass(type(index_location), TerrierIndexer):
         if issubclass(type(index_location), TerrierIndexer):


### PR DESCRIPTION
closes: #639 