### PR TITLE
feat: add __eq__ and __hash__ to operator transformers and Retriever

### DIFF
--- a/pyterrier/_ops.py
+++ b/pyterrier/_ops.py
@@ -188,6 +188,14 @@ class ScalarProduct(Transformer):
     def __repr__(self):
         return f'ScalarProduct({self.scalar!r})'
 
+    def __eq__(self, other):
+        if not isinstance(other, ScalarProduct):
+            return NotImplemented
+        return self.scalar == other.scalar
+
+    def __hash__(self):
+        return hash(('ScalarProduct', self.scalar))
+
 class RankCutoff(Transformer):
     """
         Filters the input by rank<k for each query in the input
@@ -203,7 +211,15 @@ class RankCutoff(Transformer):
 
     def __repr__(self):
         return f'RankCutoff({self.k!r})'
-    
+
+    def __eq__(self, other):
+        if not isinstance(other, RankCutoff):
+            return NotImplemented
+        return self.k == other.k
+
+    def __hash__(self):
+        return hash(('RankCutoff', self.k))
+
     def schematic(self, *, input_columns = None): 
         return {'label': f'% {self.k}'}
 
@@ -340,6 +356,14 @@ class FeatureUnion(NAryTransformerBase):
     def __repr__(self):
         return '(' + ' ** '.join([str(t) for t in self._transformers]) + ')'
 
+    def __eq__(self, other):
+        if not isinstance(other, FeatureUnion):
+            return NotImplemented
+        return self._transformers == other._transformers
+
+    def __hash__(self):
+        return hash(('FeatureUnion', self._transformers))
+
 class Compose(NAryTransformerBase):
     """ 
         This class allows pipeline components to be chained together using the "then" operator.
@@ -406,6 +430,14 @@ class Compose(NAryTransformerBase):
 
     def __repr__(self):
         return '(' + ' >> '.join([str(t) for t in self._transformers]) + ')'
+
+    def __eq__(self, other):
+        if not isinstance(other, Compose):
+            return NotImplemented
+        return self._transformers == other._transformers
+
+    def __hash__(self):
+        return hash(('Compose', self._transformers))
 
     def compile(self, verbose: bool = False) -> Transformer:
         """Returns a new transformer that iteratively fuses adjacent transformers to form a more efficient pipeline."""

--- a/pyterrier/terrier/retriever.py
+++ b/pyterrier/terrier/retriever.py
@@ -500,6 +500,28 @@ class Retriever(pt.Transformer):
             str(self.controls),
             str(self.properties)
             ]) + ")"
+    
+    def __eq__(self, other):
+        if not isinstance(other, Retriever):
+            return NotImplemented
+        return (
+            self.indexref == other.indexref and
+            self.controls == other.controls and
+            self.properties == other.properties and
+            self.metadata == other.metadata and
+            self.threads == other.threads and
+            self.verbose == other.verbose
+        )
+
+    def __hash__(self):
+        return hash((
+            'Retriever',
+            str(self.indexref),
+            tuple(sorted(self.controls.items())),
+            tuple(sorted(self.properties.items())),
+            tuple(sorted(self.metadata)),
+            self.threads,
+        ))
 
     def __str__(self):
         return "TerrierRetr(" + self.controls["wmodel"] + ")"

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -1,0 +1,204 @@
+import unittest
+import pyterrier as pt
+from pyterrier._ops import RankCutoff, ScalarProduct, Compose, FeatureUnion
+from .base import TempDirTestCase
+
+
+class TestOpsEquality(unittest.TestCase):
+    """Tests for __eq__ and __hash__ on operator transformers (no Java required)."""
+
+    # ── RankCutoff ──────────────────────────────────────────────────────────
+
+    def test_rankcutoff_eq_same_k(self):
+        self.assertEqual(RankCutoff(10), RankCutoff(10))
+
+    def test_rankcutoff_eq_different_k(self):
+        self.assertNotEqual(RankCutoff(10), RankCutoff(20))
+
+    def test_rankcutoff_eq_default_k(self):
+        self.assertEqual(RankCutoff(), RankCutoff(1000))
+
+    def test_rankcutoff_eq_wrong_type(self):
+        self.assertNotEqual(RankCutoff(10), "not a transformer")
+
+    def test_rankcutoff_hash_same_k(self):
+        self.assertEqual(hash(RankCutoff(10)), hash(RankCutoff(10)))
+
+    def test_rankcutoff_hash_different_k(self):
+        self.assertNotEqual(hash(RankCutoff(10)), hash(RankCutoff(20)))
+
+    def test_rankcutoff_in_set(self):
+        s = {RankCutoff(10), RankCutoff(10), RankCutoff(20)}
+        self.assertEqual(len(s), 2)
+
+    def test_rankcutoff_as_dict_key(self):
+        d = {RankCutoff(10): "ten", RankCutoff(20): "twenty"}
+        self.assertEqual(d[RankCutoff(10)], "ten")
+
+    # ── ScalarProduct ────────────────────────────────────────────────────────
+
+    def test_scalarproduct_eq_same(self):
+        self.assertEqual(ScalarProduct(2.0), ScalarProduct(2.0))
+
+    def test_scalarproduct_eq_different(self):
+        self.assertNotEqual(ScalarProduct(2.0), ScalarProduct(3.0))
+
+    def test_scalarproduct_eq_wrong_type(self):
+        self.assertNotEqual(ScalarProduct(2.0), 2.0)
+
+    def test_scalarproduct_hash_same(self):
+        self.assertEqual(hash(ScalarProduct(2.0)), hash(ScalarProduct(2.0)))
+
+    def test_scalarproduct_hash_different(self):
+        self.assertNotEqual(hash(ScalarProduct(2.0)), hash(ScalarProduct(3.0)))
+
+    def test_scalarproduct_in_set(self):
+        s = {ScalarProduct(2.0), ScalarProduct(2.0), ScalarProduct(3.0)}
+        self.assertEqual(len(s), 2)
+
+    # ── Compose ──────────────────────────────────────────────────────────────
+
+    def test_compose_eq_same(self):
+        a = RankCutoff(10) >> ScalarProduct(2.0)
+        b = RankCutoff(10) >> ScalarProduct(2.0)
+        self.assertEqual(a, b)
+
+    def test_compose_eq_different_order(self):
+        a = RankCutoff(10) >> ScalarProduct(2.0)
+        b = ScalarProduct(2.0) >> RankCutoff(10)
+        self.assertNotEqual(a, b)
+
+    def test_compose_eq_different_k(self):
+        a = RankCutoff(10) >> ScalarProduct(2.0)
+        b = RankCutoff(99) >> ScalarProduct(2.0)
+        self.assertNotEqual(a, b)
+
+    def test_compose_eq_wrong_type(self):
+        a = RankCutoff(10) >> ScalarProduct(2.0)
+        self.assertNotEqual(a, "not a pipeline")
+
+    def test_compose_hash_same(self):
+        a = RankCutoff(10) >> ScalarProduct(2.0)
+        b = RankCutoff(10) >> ScalarProduct(2.0)
+        self.assertEqual(hash(a), hash(b))
+
+    def test_compose_hash_different(self):
+        a = RankCutoff(10) >> ScalarProduct(2.0)
+        b = RankCutoff(99) >> ScalarProduct(2.0)
+        self.assertNotEqual(hash(a), hash(b))
+
+    def test_compose_in_set(self):
+        a = RankCutoff(10) >> ScalarProduct(2.0)
+        b = RankCutoff(10) >> ScalarProduct(2.0)
+        c = RankCutoff(99) >> ScalarProduct(2.0)
+        s = {a, b, c}
+        self.assertEqual(len(s), 2)
+
+    def test_compose_three_stages_eq(self):
+        a = RankCutoff(10) >> ScalarProduct(2.0) >> RankCutoff(5)
+        b = RankCutoff(10) >> ScalarProduct(2.0) >> RankCutoff(5)
+        self.assertEqual(a, b)
+
+    # ── FeatureUnion ─────────────────────────────────────────────────────────
+
+    def test_featureunion_eq_same(self):
+        a = ScalarProduct(1.0) ** ScalarProduct(2.0)
+        b = ScalarProduct(1.0) ** ScalarProduct(2.0)
+        self.assertEqual(a, b)
+
+    def test_featureunion_eq_different(self):
+        a = ScalarProduct(1.0) ** ScalarProduct(2.0)
+        b = ScalarProduct(1.0) ** ScalarProduct(9.0)
+        self.assertNotEqual(a, b)
+
+    def test_featureunion_hash_same(self):
+        a = ScalarProduct(1.0) ** ScalarProduct(2.0)
+        b = ScalarProduct(1.0) ** ScalarProduct(2.0)
+        self.assertEqual(hash(a), hash(b))
+
+    def test_featureunion_in_set(self):
+        a = ScalarProduct(1.0) ** ScalarProduct(2.0)
+        b = ScalarProduct(1.0) ** ScalarProduct(2.0)
+        c = ScalarProduct(1.0) ** ScalarProduct(9.0)
+        s = {a, b, c}
+        self.assertEqual(len(s), 2)
+
+
+class TestRetrieverEquality(TempDirTestCase):
+    """Tests for Retriever.__eq__ and __hash__ (requires Java + index)."""
+
+    def _make_index(self):
+        import pandas as pd
+        docs = pd.DataFrame({
+            'docno': ['d1', 'd2', 'd3'],
+            'text': ['cat sat mat', 'dog ran far', 'bird flew high']
+        })
+        indexer = pt.IterDictIndexer(
+            self.test_dir,
+            stopwords=pt.TerrierStopwords.none,
+            stemmer=pt.TerrierStemmer.none,
+        )
+        return indexer.index(docs.to_dict(orient='records'))
+
+    def test_retriever_eq_same_config(self):
+        indexref = self._make_index()
+        r1 = pt.terrier.Retriever(indexref, wmodel="BM25")
+        r2 = pt.terrier.Retriever(indexref, wmodel="BM25")
+        self.assertEqual(r1, r2)
+
+    def test_retriever_eq_different_wmodel(self):
+        indexref = self._make_index()
+        r1 = pt.terrier.Retriever(indexref, wmodel="BM25")
+        r2 = pt.terrier.Retriever(indexref, wmodel="TF_IDF")
+        self.assertNotEqual(r1, r2)
+
+    def test_retriever_eq_different_num_results(self):
+        indexref = self._make_index()
+        r1 = pt.terrier.Retriever(indexref, wmodel="BM25", num_results=10)
+        r2 = pt.terrier.Retriever(indexref, wmodel="BM25", num_results=100)
+        self.assertNotEqual(r1, r2)
+
+    def test_retriever_eq_wrong_type(self):
+        indexref = self._make_index()
+        r1 = pt.terrier.Retriever(indexref, wmodel="BM25")
+        self.assertNotEqual(r1, "not a retriever")
+
+    def test_retriever_hash_same_config(self):
+        indexref = self._make_index()
+        r1 = pt.terrier.Retriever(indexref, wmodel="BM25")
+        r2 = pt.terrier.Retriever(indexref, wmodel="BM25")
+        self.assertEqual(hash(r1), hash(r2))
+
+    def test_retriever_hash_different_wmodel(self):
+        indexref = self._make_index()
+        r1 = pt.terrier.Retriever(indexref, wmodel="BM25")
+        r2 = pt.terrier.Retriever(indexref, wmodel="TF_IDF")
+        self.assertNotEqual(hash(r1), hash(r2))
+
+    def test_retriever_in_set(self):
+        indexref = self._make_index()
+        r1 = pt.terrier.Retriever(indexref, wmodel="BM25")
+        r2 = pt.terrier.Retriever(indexref, wmodel="BM25")
+        r3 = pt.terrier.Retriever(indexref, wmodel="TF_IDF")
+        s = {r1, r2, r3}
+        self.assertEqual(len(s), 2)
+
+    def test_retriever_as_dict_key(self):
+        indexref = self._make_index()
+        r1 = pt.terrier.Retriever(indexref, wmodel="BM25")
+        r2 = pt.terrier.Retriever(indexref, wmodel="BM25")
+        d = {r1: "bm25"}
+        self.assertEqual(d[r2], "bm25")
+
+    def test_compose_retriever_eq(self):
+        """Two identical pipelines starting with the same Retriever should be equal."""
+        indexref = self._make_index()
+        r1 = pt.terrier.Retriever(indexref, wmodel="BM25")
+        r2 = pt.terrier.Retriever(indexref, wmodel="BM25")
+        cutoff1 = r1 % 10
+        cutoff2 = r2 % 10
+        self.assertEqual(cutoff1, cutoff2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements equality checking for RankCutoff, ScalarProduct, Compose, FeatureUnion (pyterrier/_ops.py) and Retriever (pyterrier/terrier/retriever.py).

This enables trie-based prefix detection in pt.Experiment (issue #649), allowing identical pipeline prefixes to be correctly identified and deduplicated for more efficient execution.

Also adds 26 tests covering equality and hashability for all affected classes.

Closes #649